### PR TITLE
Add GitHub Actions workflow: test on PR, deploy to Pages on merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Test and Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn test --watchAll=false --passWithNoTests
+        env:
+          CI: true
+
+  build:
+    name: Build
+    needs: test
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+        env:
+          CI: false
+          REACT_APP_BUILD_VERSION: ${{ github.sha }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    name: Deploy
+    needs: build
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   test:
     name: Test
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,7 +41,6 @@ jobs:
 
   build:
     name: Build
-    needs: test
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Automates the existing manual `yarn deploy` flow so merges to `main` ship to GitHub Pages without local action, and PRs get gated on tests.

## Approach

Single workflow at `.github/workflows/deploy.yml` with three jobs:

- **test** — runs only on `pull_request` to `main`. Installs deps with yarn (frozen lockfile) and runs `react-scripts test --watchAll=false --passWithNoTests` with `CI=true`.
- **build** — runs only on `push` to `main` (i.e. after merge) or `workflow_dispatch`. Builds the CRA app, sets `REACT_APP_BUILD_VERSION` to the commit SHA, and uploads `./build` via `actions/upload-pages-artifact`.
- **deploy** — consumes the artifact and publishes via `actions/deploy-pages@v4`, using the `github-pages` environment.

Tests don't re-run on the merge commit since branch protection (if enabled) ensures they already passed on the PR.

## Notes for reviewers

- Uses the modern GitHub Pages "GitHub Actions" source. **Manual setup required once**: Settings -> Pages -> Source -> "GitHub Actions". The existing `gh-pages` branch / `npm run deploy` flow can be retired afterward.
- `public/CNAME` (yasat.nl) is bundled into `build/` by CRA, so the custom domain is preserved.
- `concurrency: pages` prevents overlapping deploys.
- `CI: false` is set on the build step to avoid CRA treating warnings as errors during production build (tests still run with `CI: true`).