### PR TITLE
Pass Firebase config secrets to build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,12 @@ jobs:
         env:
           CI: false
           REACT_APP_BUILD_VERSION: ${{ github.sha }}
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
+          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.REACT_APP_FIREBASE_AUTH_DOMAIN }}
+          REACT_APP_FIREBASE_PROJECT_ID: ${{ secrets.REACT_APP_FIREBASE_PROJECT_ID }}
+          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.REACT_APP_FIREBASE_STORAGE_BUCKET }}
+          REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.REACT_APP_FIREBASE_MESSAGING_SENDER_ID }}
+          REACT_APP_FIREBASE_APP_ID: ${{ secrets.REACT_APP_FIREBASE_APP_ID }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Follow-up to #12. The previous PR was merged before the Firebase env vars were wired into the build step, so the production bundle was being built with empty Firebase config and could not connect to Firestore.

This passes the `REACT_APP_FIREBASE_*` repository secrets through to the `yarn build` step so CRA can inline them into the production bundle at build time.

After merging, the Pages deploy will rebuild with the secrets and Firestore should connect.