### PR TITLE
Rebuild The King Is Dead from the official 2nd-edition rulebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ Beyond the core score tracker, the app bundles several self-contained games reac
 | Shiplake | Dice / categories / modifiers score game |
 | Regicide | Co-op royal slayer (solo mode) |
 | Flip 7 | Press-your-luck, first to 200 |
-| The King Is Dead | Area-majority intrigue vs. 1–2 AI opponents |
+| The King Is Dead | Political intrigue in medieval Britain vs. 1–3 AI opponents |
 
-**The King Is Dead (TKID2)** — Play against 1 or 2 AI opponents for control of Britain. It is built as a pure, deterministic, action-based engine (`features/tkid2/engine/tkid2Engine.ts`) with a seeded setup, so a future online turn-based mode (human vs. human) can reuse the same engine and relay `TKID2Action` objects — mirroring the existing Play-vs-Friends pattern. The heuristic AI (`features/tkid2/ai/botPolicy.ts`) supports `easy` / `normal` / `godlike` difficulty.
+**The King Is Dead (TKID2)** — A faithful digital implementation of *The King Is Dead: Second Edition* (Peer Sylvester, Osprey Games): eight regions of Britain resolved through power struggles, single-use action cards, follower summoning, instability/French invasion, and coronation scoring with the printed tiebreakers. Both the basic game and the advanced game (secret cunning action cards) are supported, as is the four-player team variant (you + an AI ally vs. two AI). The board is rendered as an interactive SVG map in the rulebook's illuminated-manuscript style: follower cubes, control/instability/negotiation discs, the supply, France, and the numbered region-card track are all visualised and clickable.
 
-> The authoritative rulebook PDF was unavailable while building the engine, so its numeric rules (region layout, cube counts, invasion threshold) are a documented interpretation kept as constants in `tkid2Engine.ts`.
+It is built as a pure, deterministic, action-based engine (`features/tkid2/engine/tkid2Engine.ts`) with a seeded setup, so a future online turn-based mode (human vs. human) can reuse the same engine and relay `Tkid2Action` objects — mirroring the existing Play-vs-Friends pattern. The engine enumerates every legal parameter assignment for a card (`enumerateCardParams`), which drives both the guided click-by-click targeting UI (`selection.ts`) and the heuristic AI (`features/tkid2/ai/botPolicy.ts`, `easy` / `normal` / `godlike`).
 
 **Direct link** — TKID2 has its own entry URL: `https://yasat.nl/tkid2e`. Because the app is a Create React App SPA hosted on GitHub Pages (no server routing), a `public/404.html` fallback (spa-github-pages technique) restores deep-link paths, and `App.tsx` detects the `/tkid2e` path on startup and opens the game.
 

--- a/src/features/gameSelection/gameSelectionContext.tsx
+++ b/src/features/gameSelection/gameSelectionContext.tsx
@@ -45,9 +45,9 @@ export const GAMES: Record<ActiveGame, GameDefinition> = {
   tkid2: {
     id: "tkid2",
     label: "The King Is Dead",
-    darkColor: "#B07CF3",
-    lightColor: "#5B2E93",
-    tagline: "Area-majority intrigue vs. AI.",
+    darkColor: "#e0b44a",
+    lightColor: "#8e3a2e",
+    tagline: "Crown a ruler of medieval Britain.",
   },
 };
 

--- a/src/features/tkid2/ActionCardView.tsx
+++ b/src/features/tkid2/ActionCardView.tsx
@@ -1,0 +1,368 @@
+import * as React from "react";
+import { Box, Tooltip, Typography } from "@mui/material";
+import { CARD_INFO, CardId, Faction } from "./engine/tkid2Engine";
+import {
+  CARD_BACK,
+  FACTION_COLOR,
+  FONT_BODY,
+  FONT_UNCIAL,
+  GOLD,
+  INK,
+  PARCHMENT,
+  RUBRIC,
+} from "./style";
+
+/** Mini cube used in card pictograms. `faction: null` = "any/other" cube. */
+function GlyphCube({ x, y, faction, cross }: { x: number; y: number; faction: Faction | null; cross?: boolean }) {
+  const fill = faction ? FACTION_COLOR[faction].main : "#cbbd9a";
+  const stroke = faction ? FACTION_COLOR[faction].dark : "#857852";
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <rect x={-6} y={-6} width={12} height={12} rx={1.5} fill={fill} stroke={stroke} strokeWidth={1.4} />
+      {cross && (
+        <path d="M -4 -4 L 4 4 M 4 -4 L -4 4" stroke={RUBRIC} strokeWidth={1.6} strokeLinecap="round" />
+      )}
+    </g>
+  );
+}
+
+function Arrow({ x1, y1, x2, y2 }: { x1: number; y1: number; x2: number; y2: number }) {
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const ax = x2 - Math.cos(angle) * 6;
+  const ay = y2 - Math.sin(angle) * 6;
+  return (
+    <g stroke={INK} strokeWidth={1.8} fill={INK} strokeLinecap="round">
+      <line x1={x1} y1={y1} x2={ax} y2={ay} />
+      <path
+        d={`M ${x2} ${y2} L ${x2 - Math.cos(angle - 0.45) * 7} ${y2 - Math.sin(angle - 0.45) * 7} L ${x2 - Math.cos(angle + 0.45) * 7} ${y2 - Math.sin(angle + 0.45) * 7} Z`}
+        strokeWidth={0.5}
+      />
+    </g>
+  );
+}
+
+function RegionBlob({ x, y, w = 34, h = 18 }: { x: number; y: number; w?: number; h?: number }) {
+  return (
+    <ellipse
+      cx={x}
+      cy={y}
+      rx={w / 2}
+      ry={h / 2}
+      fill="none"
+      stroke={INK}
+      strokeWidth={1.5}
+      strokeDasharray="4 3"
+      opacity={0.8}
+    />
+  );
+}
+
+/** The little effect schematic drawn in the picture area of each card. */
+function CardGlyph({ cardId }: { cardId: CardId }) {
+  const inner = (() => {
+    switch (cardId) {
+      case "scottish-support":
+      case "welsh-support":
+      case "english-support": {
+        const f: Faction =
+          cardId === "scottish-support" ? "scottish" : cardId === "welsh-support" ? "welsh" : "english";
+        return (
+          <>
+            <GlyphCube x={30} y={12} faction={f} />
+            <GlyphCube x={46} y={12} faction={f} />
+            <Arrow x1={38} y1={22} x2={38} y2={38} />
+            <RegionBlob x={38} y={46} />
+          </>
+        );
+      }
+      case "assemble-1":
+      case "assemble-2":
+        return (
+          <>
+            <GlyphCube x={22} y={12} faction="scottish" />
+            <GlyphCube x={38} y={12} faction="welsh" />
+            <GlyphCube x={54} y={12} faction="english" />
+            <Arrow x1={38} y1={22} x2={38} y2={38} />
+            <RegionBlob x={38} y={46} />
+          </>
+        );
+      case "negotiate":
+        return (
+          <>
+            <rect x={14} y={14} width={18} height={26} rx={2} fill={PARCHMENT} stroke={INK} strokeWidth={1.5} />
+            <rect x={44} y={14} width={18} height={26} rx={2} fill={PARCHMENT} stroke={INK} strokeWidth={1.5} />
+            <Arrow x1={33} y1={22} x2={43} y2={22} />
+            <Arrow x1={43} y1={32} x2={33} y2={32} />
+            <circle cx={53} cy={48} r={5} fill="#fff" stroke={INK} strokeWidth={1.4} />
+          </>
+        );
+      case "manoeuvre":
+        return (
+          <>
+            <GlyphCube x={20} y={16} faction={null} />
+            <GlyphCube x={56} y={40} faction={null} />
+            <Arrow x1={28} y1={20} x2={48} y2={36} />
+            <Arrow x1={48} y1={44} x2={28} y2={24} />
+          </>
+        );
+      case "outmanoeuvre":
+        return (
+          <>
+            <GlyphCube x={16} y={26} faction={null} />
+            <GlyphCube x={56} y={16} faction={null} />
+            <GlyphCube x={56} y={38} faction={null} />
+            <Arrow x1={26} y1={22} x2={44} y2={18} />
+            <Arrow x1={44} y1={36} x2={26} y2={31} />
+          </>
+        );
+      case "spy":
+        return (
+          <>
+            <rect x={26} y={8} width={24} height={34} rx={2} fill={PARCHMENT} stroke={INK} strokeWidth={1.5} />
+            <text x={38} y={32} textAnchor="middle" fontSize={20} fontFamily={FONT_BODY} fontWeight={700} fill={RUBRIC}>
+              ?
+            </text>
+          </>
+        );
+      case "ambush":
+        return (
+          <>
+            <GlyphCube x={26} y={10} faction="scottish" />
+            <GlyphCube x={42} y={10} faction="scottish" />
+            <Arrow x1={34} y1={20} x2={34} y2={34} />
+            <RegionBlob x={34} y={42} />
+            <Arrow x1={52} y1={42} x2={62} y2={26} />
+            <GlyphCube x={64} y={16} faction={null} />
+          </>
+        );
+      case "march":
+        return (
+          <>
+            <GlyphCube x={16} y={20} faction={null} />
+            <GlyphCube x={16} y={36} faction={null} />
+            <Arrow x1={28} y1={28} x2={48} y2={28} />
+            <RegionBlob x={58} y={28} w={26} h={26} />
+          </>
+        );
+      case "plot":
+        return (
+          <>
+            {[22, 38, 54].map((x) => (
+              <path
+                key={x}
+                d={`M ${x - 7} 30 L ${x - 8} 18 L ${x - 3} 24 L ${x} 15 L ${x + 3} 24 L ${x + 8} 18 L ${x + 7} 30 Z`}
+                fill={GOLD}
+                stroke="#8a6d24"
+                strokeWidth={1.2}
+              />
+            ))}
+          </>
+        );
+      case "aid":
+        return (
+          <>
+            <rect x={22} y={6} width={32} height={16} rx={3} fill="none" stroke={INK} strokeWidth={1.4} />
+            <GlyphCube x={31} y={14} faction={null} />
+            <GlyphCube x={45} y={14} faction={null} />
+            <Arrow x1={38} y1={26} x2={38} y2={38} />
+            <RegionBlob x={38} y={46} />
+          </>
+        );
+      case "influence":
+        return (
+          <>
+            <GlyphCube x={16} y={26} faction="english" />
+            <GlyphCube x={56} y={16} faction="english" cross />
+            <GlyphCube x={56} y={38} faction="english" cross />
+            <Arrow x1={26} y1={22} x2={44} y2={18} />
+            <Arrow x1={44} y1={36} x2={26} y2={31} />
+          </>
+        );
+      case "dispute":
+        return (
+          <>
+            <GlyphCube x={20} y={22} faction="welsh" />
+            <GlyphCube x={56} y={34} faction="welsh" cross />
+            <Arrow x1={30} y1={24} x2={46} y2={31} />
+            <Arrow x1={46} y1={38} x2={30} y2={30} />
+          </>
+        );
+      case "edict":
+        return (
+          <>
+            <GlyphCube x={16} y={14} faction="scottish" />
+            <GlyphCube x={16} y={36} faction="scottish" />
+            <GlyphCube x={60} y={14} faction="scottish" cross />
+            <GlyphCube x={60} y={36} faction="scottish" cross />
+            <Arrow x1={27} y1={20} x2={49} y2={20} />
+            <Arrow x1={49} y1={32} x2={27} y2={32} />
+          </>
+        );
+      case "resist":
+        return (
+          <>
+            <GlyphCube x={30} y={12} faction="scottish" cross />
+            <GlyphCube x={46} y={12} faction="scottish" cross />
+            <Arrow x1={38} y1={22} x2={38} y2={38} />
+            <RegionBlob x={38} y={46} />
+          </>
+        );
+      case "quell":
+        return (
+          <>
+            <GlyphCube x={14} y={14} faction="welsh" />
+            <Arrow x1={20} y1={22} x2={26} y2={34} />
+            <RegionBlob x={38} y={44} />
+            <GlyphCube x={52} y={10} faction={null} />
+            <GlyphCube x={66} y={10} faction={null} />
+            <Arrow x1={58} y1={20} x2={48} y2={36} />
+          </>
+        );
+      case "suppress":
+        return (
+          <>
+            <GlyphCube x={16} y={10} faction="english" />
+            <GlyphCube x={32} y={10} faction={null} />
+            <Arrow x1={24} y1={20} x2={30} y2={34} />
+            <RegionBlob x={40} y={44} />
+            <GlyphCube x={62} y={12} faction={null} />
+            <Arrow x1={60} y1={22} x2={50} y2={36} />
+          </>
+        );
+      case "muster":
+        return (
+          <>
+            <GlyphCube x={14} y={14} faction="scottish" />
+            <Arrow x1={20} y1={22} x2={26} y2={34} />
+            <RegionBlob x={38} y={44} />
+            <GlyphCube x={52} y={10} faction={null} />
+            <GlyphCube x={66} y={10} faction={null} />
+            <Arrow x1={58} y1={20} x2={48} y2={36} />
+          </>
+        );
+      default:
+        return null;
+    }
+  })();
+  return (
+    <svg viewBox="0 0 76 58" style={{ width: "100%", height: "100%" }}>
+      {inner}
+    </svg>
+  );
+}
+
+export interface ActionCardViewProps {
+  cardId: CardId;
+  disabled?: boolean;
+  selected?: boolean;
+  faceDown?: boolean;
+  small?: boolean;
+  onClick?: () => void;
+}
+
+/**
+ * A hand card, styled after the rulebook: parchment face, dark red frame,
+ * effect schematic on top and the card's name in a banner below. Cunning
+ * cards carry the ✠ marks around their title, as in the printed game.
+ */
+export function ActionCardView({
+  cardId,
+  disabled,
+  selected,
+  faceDown,
+  small,
+  onClick,
+}: ActionCardViewProps) {
+  const info = CARD_INFO[cardId];
+  const w = small ? 74 : 104;
+  const h = small ? 104 : 146;
+
+  if (faceDown) {
+    return (
+      <Box
+        sx={{
+          width: w,
+          height: h,
+          borderRadius: "7px",
+          border: `2px solid #4a1812`,
+          background: `repeating-linear-gradient(45deg, ${CARD_BACK}, ${CARD_BACK} 7px, #6e2820 7px, #6e2820 14px)`,
+          boxShadow: "0 2px 5px rgba(40,20,10,0.4)",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Tooltip title={info.text} arrow enterTouchDelay={350}>
+      <Box
+        onClick={disabled ? undefined : onClick}
+        sx={{
+          width: w,
+          height: h,
+          borderRadius: "7px",
+          border: `2.5px solid ${selected ? GOLD : "#5d2019"}`,
+          outline: selected ? `2px solid ${GOLD}` : "none",
+          background: `linear-gradient(160deg, #f5ecd2 0%, ${PARCHMENT} 55%, #e7d6a8 100%)`,
+          boxShadow: selected
+            ? `0 0 12px ${GOLD}`
+            : "0 2px 5px rgba(40,20,10,0.35)",
+          cursor: disabled || !onClick ? "default" : "pointer",
+          opacity: disabled ? 0.45 : 1,
+          display: "flex",
+          flexDirection: "column",
+          p: small ? "4px" : "6px",
+          transition: "transform 120ms ease, box-shadow 120ms ease",
+          "&:hover":
+            disabled || !onClick
+              ? {}
+              : { transform: "translateY(-4px)", boxShadow: "0 6px 14px rgba(40,20,10,0.45)" },
+          flexShrink: 0,
+          userSelect: "none",
+        }}
+      >
+        <Box
+          sx={{
+            flexGrow: 1,
+            border: `1px solid ${CARD_BACK}`,
+            borderRadius: "4px",
+            background: "rgba(255,252,240,0.55)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+            mb: "4px",
+          }}
+        >
+          <CardGlyph cardId={cardId} />
+        </Box>
+        <Box
+          sx={{
+            background: `linear-gradient(180deg, #fdf6e4, #efe0ba)`,
+            border: `1px solid ${CARD_BACK}`,
+            borderRadius: "4px",
+            px: 0.25,
+            py: small ? "1px" : "3px",
+            textAlign: "center",
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: FONT_UNCIAL,
+              fontSize: small ? "0.5rem" : "0.62rem",
+              lineHeight: 1.15,
+              color: RUBRIC,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {info.cunning ? `✠ ${info.name} ✠` : info.name}
+          </Typography>
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+}
+
+export default ActionCardView;

--- a/src/features/tkid2/BoardMap.tsx
+++ b/src/features/tkid2/BoardMap.tsx
@@ -1,0 +1,519 @@
+import * as React from "react";
+import {
+  FACTIONS,
+  Faction,
+  RegionId,
+  Tkid2State,
+  regionName,
+} from "./engine/tkid2Engine";
+import { CubeRef, cubeKey } from "./selection";
+import {
+  FACTION_COLOR,
+  FONT_BODY,
+  FRANCE_COLOR,
+  GOLD,
+  INK,
+  INK_FADED,
+  INSTABILITY,
+  PARCHMENT,
+  REGION_COLOR,
+  RUBRIC,
+  SEA,
+} from "./style";
+
+/** Hand-tuned geometry for the stylised portolan chart of Britain. */
+const SHAPES: Record<
+  RegionId,
+  { path: string; label: [number, number]; cubes: [number, number] }
+> = {
+  moray: {
+    path: "M 210 42 C 255 24 330 20 388 32 C 436 42 456 78 452 118 C 449 146 431 158 400 161 L 205 170 C 172 170 152 142 158 110 C 163 80 182 53 210 42 Z",
+    label: [300, 78],
+    cubes: [298, 122],
+  },
+  strathclyde: {
+    path: "M 205 170 L 400 161 C 428 160 441 180 437 204 C 434 227 417 240 392 242 L 190 254 C 160 255 144 233 149 208 C 153 187 176 171 205 170 Z",
+    label: [293, 196],
+    cubes: [293, 226],
+  },
+  lancaster: {
+    path: "M 190 254 L 297 249 L 302 428 L 178 435 C 153 435 141 413 145 388 L 152 292 C 154 270 168 256 190 254 Z",
+    label: [228, 283],
+    cubes: [226, 338],
+  },
+  northumbria: {
+    path: "M 297 249 L 392 242 C 420 240 444 254 449 280 L 466 388 C 470 413 456 427 432 428 L 302 428 Z",
+    label: [374, 283],
+    cubes: [376, 340],
+  },
+  gwynedd: {
+    path: "M 178 435 L 254 431 L 257 568 L 192 575 C 150 580 116 561 111 526 C 106 492 126 473 138 458 C 148 444 160 436 178 435 Z",
+    label: [184, 462],
+    cubes: [184, 512],
+  },
+  warwick: {
+    path: "M 254 431 L 302 428 L 390 430 L 393 550 C 393 562 381 568 366 569 L 257 568 Z",
+    label: [322, 456],
+    cubes: [322, 505],
+  },
+  essex: {
+    path: "M 390 430 L 432 428 C 456 427 468 434 471 454 L 486 540 C 490 566 476 582 452 586 L 394 592 C 392 578 393 562 393 550 L 390 430 Z",
+    label: [436, 466],
+    cubes: [432, 518],
+  },
+  devon: {
+    path: "M 257 568 L 366 569 L 394 592 C 390 604 377 640 330 655 C 285 669 205 700 158 685 C 118 672 124 640 155 622 C 188 603 224 585 257 568 Z",
+    label: [268, 598],
+    cubes: [258, 634],
+  },
+};
+
+const FRANCE_PATH =
+  "M 476 648 C 528 630 598 634 634 654 L 640 786 L 470 786 C 452 748 456 694 476 648 Z";
+
+const CUBE = 19;
+const CUBE_GAP = 23;
+const CUBES_PER_ROW = 4;
+const MAX_VISIBLE_CUBES = 12;
+
+export interface BoardMapProps {
+  state: Tkid2State;
+  contested: RegionId | null;
+  /** Regions the current selection step accepts (clickable + glowing). */
+  highlightRegions?: Set<RegionId>;
+  /** Cube keys the current selection step accepts. */
+  highlightCubes?: Set<string>;
+  /** Cubes already picked this selection (drawn with a gold ring). */
+  pickedCubes?: CubeRef[];
+  onRegionClick?: (id: RegionId) => void;
+  onCubeClick?: (cube: CubeRef) => void;
+}
+
+function Cube({
+  x,
+  y,
+  faction,
+  clickable,
+  picked,
+  dim,
+  onClick,
+}: {
+  x: number;
+  y: number;
+  faction: Faction;
+  clickable: boolean;
+  picked: boolean;
+  dim: boolean;
+  onClick?: () => void;
+}) {
+  const c = FACTION_COLOR[faction];
+  return (
+    <g
+      transform={`translate(${x}, ${y})`}
+      onClick={
+        clickable && onClick
+          ? (e) => {
+              e.stopPropagation();
+              onClick();
+            }
+          : undefined
+      }
+      style={{ cursor: clickable ? "pointer" : "default" }}
+      opacity={dim ? 0.35 : 1}
+    >
+      {clickable && (
+        <rect
+          className="tkid2-pulse"
+          x={-CUBE / 2 - 3.5}
+          y={-CUBE / 2 - 3.5}
+          width={CUBE + 7}
+          height={CUBE + 7}
+          rx={4}
+          fill="none"
+          stroke="#fffbe8"
+          strokeWidth={2.5}
+        />
+      )}
+      <rect
+        x={-CUBE / 2}
+        y={-CUBE / 2}
+        width={CUBE}
+        height={CUBE}
+        rx={2.5}
+        fill={c.main}
+        stroke={picked ? GOLD : c.dark}
+        strokeWidth={picked ? 3.5 : 1.8}
+      />
+      {/* light bevel */}
+      <path
+        d={`M ${-CUBE / 2 + 2.5} ${CUBE / 2 - 3} L ${-CUBE / 2 + 2.5} ${-CUBE / 2 + 2.5} L ${CUBE / 2 - 3} ${-CUBE / 2 + 2.5}`}
+        fill="none"
+        stroke={c.light}
+        strokeWidth={2}
+        strokeLinecap="round"
+        opacity={0.9}
+      />
+    </g>
+  );
+}
+
+function RegionCubes({
+  state,
+  regionId,
+  highlightCubes,
+  pickedCubes,
+  onCubeClick,
+  anyHighlight,
+}: {
+  state: Tkid2State;
+  regionId: RegionId;
+  highlightCubes?: Set<string>;
+  pickedCubes?: CubeRef[];
+  onCubeClick?: (cube: CubeRef) => void;
+  anyHighlight: boolean;
+}) {
+  const cubes = state.regions[regionId].cubes;
+  const list: Faction[] = [];
+  for (const f of FACTIONS) {
+    for (let i = 0; i < cubes[f]; i++) list.push(f);
+  }
+  const [cx, cy] = SHAPES[regionId].cubes;
+  const visible = list.slice(0, MAX_VISIBLE_CUBES);
+  const extra = list.length - visible.length;
+  const rows = Math.ceil(visible.length / CUBES_PER_ROW);
+
+  // Track how many cubes of each faction in this region are "picked" so the
+  // right number of gold rings is drawn.
+  const pickedCount = new Map<string, number>();
+  for (const p of pickedCubes ?? []) {
+    if (p.regionId !== regionId) continue;
+    pickedCount.set(p.faction, (pickedCount.get(p.faction) ?? 0) + 1);
+  }
+  const seen = new Map<string, number>();
+
+  return (
+    <g>
+      {visible.map((f, i) => {
+        const row = Math.floor(i / CUBES_PER_ROW);
+        const inRow = Math.min(visible.length - row * CUBES_PER_ROW, CUBES_PER_ROW);
+        const col = i % CUBES_PER_ROW;
+        const x = cx + (col - (inRow - 1) / 2) * CUBE_GAP;
+        const y = cy + (row - (rows - 1) / 2) * CUBE_GAP;
+        const key = cubeKey({ regionId, faction: f });
+        const idx = seen.get(f) ?? 0;
+        seen.set(f, idx + 1);
+        const picked = idx < (pickedCount.get(f) ?? 0);
+        const clickable = !!highlightCubes?.has(key) && !!onCubeClick;
+        return (
+          <Cube
+            key={`${f}-${i}`}
+            x={x}
+            y={y}
+            faction={f}
+            clickable={clickable}
+            picked={picked}
+            dim={anyHighlight && !clickable && !picked}
+            onClick={() => onCubeClick?.({ regionId, faction: f })}
+          />
+        );
+      })}
+      {extra > 0 && (
+        <text
+          x={cx + ((CUBES_PER_ROW - 1) / 2 + 1) * CUBE_GAP}
+          y={cy + ((rows - 1) / 2) * CUBE_GAP + 5}
+          fontSize={14}
+          fontFamily={FONT_BODY}
+          fill={INK}
+          fontWeight={700}
+        >
+          +{extra}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function ControlDisc({ x, y, faction }: { x: number; y: number; faction: Faction }) {
+  const c = FACTION_COLOR[faction];
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <circle r={13} fill={c.main} stroke={c.dark} strokeWidth={2.5} />
+      <circle r={7.5} fill="none" stroke={c.light} strokeWidth={2} opacity={0.9} />
+    </g>
+  );
+}
+
+function InstabilityDisc({ x, y }: { x: number; y: number }) {
+  return (
+    <g transform={`translate(${x}, ${y})`}>
+      <circle r={13} fill={INSTABILITY} stroke="#2b1e12" strokeWidth={2.5} />
+      <circle r={7.5} fill="none" stroke="#6d5233" strokeWidth={2} opacity={0.9} />
+    </g>
+  );
+}
+
+function RegionLabel({ regionId, contested }: { regionId: RegionId; contested: boolean }) {
+  const [x, y] = SHAPES[regionId].label;
+  const name = regionName(regionId);
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor="middle"
+      fontFamily={FONT_BODY}
+      fontSize={17}
+      fontWeight={700}
+      fill={INK}
+      style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 4, letterSpacing: 0.5 }}
+    >
+      <tspan fill={contested ? RUBRIC : RUBRIC}>{name.charAt(0)}</tspan>
+      <tspan>{name.slice(1)}</tspan>
+    </text>
+  );
+}
+
+export function BoardMap({
+  state,
+  contested,
+  highlightRegions,
+  highlightCubes,
+  pickedCubes,
+  onRegionClick,
+  onCubeClick,
+}: BoardMapProps) {
+  const anyRegionHighlight = !!highlightRegions && highlightRegions.size > 0;
+  const anyCubeHighlight = !!highlightCubes && highlightCubes.size > 0;
+
+  return (
+    <svg
+      viewBox="0 0 680 800"
+      style={{ width: "100%", height: "auto", display: "block" }}
+      role="img"
+      aria-label="Map of Britain"
+    >
+      <style>{`
+        .tkid2-pulse { animation: tkid2pulse 1.1s ease-in-out infinite; }
+        .tkid2-region-glow { animation: tkid2glow 1.2s ease-in-out infinite; }
+        @keyframes tkid2pulse { 0%,100% { opacity: 0.25; } 50% { opacity: 1; } }
+        @keyframes tkid2glow { 0%,100% { stroke-opacity: 0.35; } 50% { stroke-opacity: 1; } }
+      `}</style>
+
+      {/* Sea */}
+      <rect x={0} y={0} width={680} height={800} rx={10} fill={SEA} />
+      {/* Portolan rhumb lines */}
+      <g stroke={INK_FADED} strokeWidth={0.7} opacity={0.18}>
+        {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => {
+          const angle = (i * Math.PI) / 8;
+          const x = 90 + Math.cos(angle) * 900;
+          const y = 700 - Math.sin(angle) * 900;
+          return <line key={`a${i}`} x1={90} y1={700} x2={x} y2={y} />;
+        })}
+        {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => {
+          const angle = Math.PI / 2 + (i * Math.PI) / 8;
+          const x = 620 + Math.cos(angle) * 900;
+          const y = 120 + Math.sin(angle) * 900;
+          return <line key={`b${i}`} x1={620} y1={120} x2={x} y2={y} />;
+        })}
+      </g>
+      <circle cx={90} cy={700} r={26} fill="none" stroke={RUBRIC} strokeWidth={1.4} opacity={0.5} />
+      <circle cx={90} cy={700} r={19} fill="none" stroke={INK_FADED} strokeWidth={1} opacity={0.5} />
+      <path d="M 90 678 L 95 695 L 90 691 L 85 695 Z" fill={RUBRIC} opacity={0.7} />
+
+      {/* Regions */}
+      {(Object.keys(SHAPES) as RegionId[]).map((id) => {
+        const shape = SHAPES[id];
+        const color = REGION_COLOR[id];
+        const region = state.regions[id];
+        const isContested = contested === id;
+        const highlighted = !!highlightRegions?.has(id);
+        const dimRegion = anyRegionHighlight && !highlighted;
+        return (
+          <g
+            key={id}
+            onClick={highlighted && onRegionClick ? () => onRegionClick(id) : undefined}
+            style={{ cursor: highlighted ? "pointer" : "default" }}
+            opacity={dimRegion ? 0.45 : 1}
+          >
+            <path
+              d={shape.path}
+              fill={color.fill}
+              stroke={color.edge}
+              strokeWidth={2.5}
+              strokeLinejoin="round"
+            />
+            {isContested && (
+              <path
+                d={shape.path}
+                fill="none"
+                stroke={GOLD}
+                strokeWidth={5}
+                strokeDasharray="10 7"
+                strokeLinejoin="round"
+                className="tkid2-region-glow"
+              />
+            )}
+            {highlighted && (
+              <path
+                d={shape.path}
+                fill="rgba(255,251,232,0.25)"
+                stroke="#fffbe8"
+                strokeWidth={3.5}
+                strokeLinejoin="round"
+                className="tkid2-region-glow"
+              />
+            )}
+            <RegionLabel regionId={id} contested={isContested} />
+            {isContested && (
+              <text
+                x={shape.label[0]}
+                y={shape.label[1] + 16}
+                textAnchor="middle"
+                fontSize={11.5}
+                fontFamily={FONT_BODY}
+                fontStyle="italic"
+                fill={RUBRIC}
+                style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 3 }}
+              >
+                ⚔ contested ⚔
+              </text>
+            )}
+            {region.control && (
+              <ControlDisc
+                x={SHAPES[id].cubes[0]}
+                y={SHAPES[id].cubes[1]}
+                faction={region.control}
+              />
+            )}
+            {region.unstable && (
+              <InstabilityDisc x={SHAPES[id].cubes[0]} y={SHAPES[id].cubes[1]} />
+            )}
+            <RegionCubes
+              state={state}
+              regionId={id}
+              highlightCubes={highlightCubes}
+              pickedCubes={pickedCubes}
+              onCubeClick={onCubeClick}
+              anyHighlight={anyCubeHighlight}
+            />
+          </g>
+        );
+      })}
+
+      {/* France */}
+      <g opacity={anyRegionHighlight ? 0.55 : 1}>
+        <path
+          d={FRANCE_PATH}
+          fill={FRANCE_COLOR.fill}
+          stroke={FRANCE_COLOR.edge}
+          strokeWidth={2.5}
+          strokeLinejoin="round"
+        />
+        <text
+          x={552}
+          y={680}
+          textAnchor="middle"
+          fontFamily={FONT_BODY}
+          fontSize={17}
+          fontWeight={700}
+          fill={INK}
+          style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 4 }}
+        >
+          <tspan fill={RUBRIC}>F</tspan>
+          <tspan>rance</tspan>
+        </text>
+        {Array.from({ length: state.instabilityInFrance }, (_, i) => (
+          <InstabilityDisc key={i} x={518 + i * 34} y={718} />
+        ))}
+        {state.instabilityInFrance === 0 && (
+          <text
+            x={552}
+            y={724}
+            textAnchor="middle"
+            fontSize={12}
+            fontFamily={FONT_BODY}
+            fontStyle="italic"
+            fill="#26303f"
+          >
+            invasion!
+          </text>
+        )}
+      </g>
+
+      {/* Supply */}
+      <g opacity={anyRegionHighlight || anyCubeHighlight ? 0.55 : 1}>
+        <rect
+          x={484}
+          y={36}
+          width={176}
+          height={170}
+          rx={12}
+          fill={PARCHMENT}
+          stroke={GOLD}
+          strokeWidth={2.5}
+        />
+        <rect
+          x={490}
+          y={42}
+          width={164}
+          height={158}
+          rx={9}
+          fill="none"
+          stroke={RUBRIC}
+          strokeWidth={1}
+          opacity={0.5}
+        />
+        <text
+          x={572}
+          y={68}
+          textAnchor="middle"
+          fontFamily={FONT_BODY}
+          fontSize={16}
+          fontWeight={700}
+          fill={RUBRIC}
+          style={{ letterSpacing: 1.5 }}
+        >
+          SUPPLY
+        </text>
+        {FACTIONS.map((f, i) => {
+          const c = FACTION_COLOR[f];
+          const y = 96 + i * 36;
+          return (
+            <g key={f}>
+              <rect
+                x={508}
+                y={y - CUBE / 2}
+                width={CUBE}
+                height={CUBE}
+                rx={2.5}
+                fill={c.main}
+                stroke={c.dark}
+                strokeWidth={1.8}
+              />
+              <text
+                x={538}
+                y={y + 5.5}
+                fontFamily={FONT_BODY}
+                fontSize={15}
+                fill={INK}
+              >
+                × {state.supply[f]}
+              </text>
+              <text
+                x={578}
+                y={y + 5.5}
+                fontFamily={FONT_BODY}
+                fontSize={12.5}
+                fill={INK_FADED}
+                fontStyle="italic"
+              >
+                {f}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+}
+
+export default BoardMap;

--- a/src/features/tkid2/RegionCardTrack.tsx
+++ b/src/features/tkid2/RegionCardTrack.tsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+import { Box, Typography } from "@mui/material";
+import { RegionId, Tkid2State, regionName } from "./engine/tkid2Engine";
+import {
+  CARD_BACK,
+  FONT_BODY,
+  GOLD,
+  INK,
+  NEGOTIATION,
+  PARCHMENT,
+  REGION_COLOR,
+  RUBRIC,
+} from "./style";
+
+export interface RegionCardTrackProps {
+  state: Tkid2State;
+  contested: RegionId | null;
+  /** Slot positions that can be clicked right now (Negotiate). */
+  highlightSlots?: Set<number>;
+  /** Slots already picked during a Negotiate selection. */
+  pickedSlots?: number[];
+  onSlotClick?: (position: number) => void;
+}
+
+/**
+ * The eight numbered spaces around the board with their region cards, drawn
+ * as a horizontal track. The lowest-numbered face-up card is the region whose
+ * power struggle will be resolved next.
+ */
+export function RegionCardTrack({
+  state,
+  contested,
+  highlightSlots,
+  pickedSlots,
+  onSlotClick,
+}: RegionCardTrackProps) {
+  const anyHighlight = !!highlightSlots && highlightSlots.size > 0;
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: 1,
+        overflowX: "auto",
+        pb: 0.5,
+        px: 0.5,
+        justifyContent: { xs: "flex-start", md: "center" },
+      }}
+    >
+      {state.slots.map((slot) => {
+        const highlighted = !!highlightSlots?.has(slot.position);
+        const picked = !!pickedSlots?.includes(slot.position);
+        const isContested = slot.faceUp && slot.regionId === contested;
+        const color = REGION_COLOR[slot.regionId];
+        return (
+          <Box
+            key={slot.position}
+            data-slot={slot.position}
+            data-slot-active={highlighted ? "1" : "0"}
+            onClick={highlighted && onSlotClick ? () => onSlotClick(slot.position) : undefined}
+            sx={{
+              flexShrink: 0,
+              width: 76,
+              textAlign: "center",
+              cursor: highlighted ? "pointer" : "default",
+              opacity: anyHighlight && !highlighted && !picked ? 0.45 : 1,
+            }}
+          >
+            {/* Numbered space */}
+            <Typography
+              sx={{
+                fontFamily: FONT_BODY,
+                fontWeight: 700,
+                fontSize: "0.8rem",
+                color: isContested ? RUBRIC : INK,
+              }}
+            >
+              {slot.position}
+              {isContested ? " ⚔" : ""}
+            </Typography>
+            <Box
+              sx={{
+                height: 96,
+                borderRadius: "6px",
+                border: `2.5px solid ${
+                  picked ? GOLD : isContested ? RUBRIC : highlighted ? "#fffbe8" : "#5d2019"
+                }`,
+                boxShadow: picked || highlighted ? `0 0 10px ${GOLD}` : "0 2px 4px rgba(40,20,10,0.35)",
+                background: slot.faceUp
+                  ? `linear-gradient(165deg, #f5ecd2, ${PARCHMENT})`
+                  : `repeating-linear-gradient(45deg, ${CARD_BACK}, ${CARD_BACK} 6px, #6e2820 6px, #6e2820 12px)`,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                position: "relative",
+                p: "4px",
+                transition: "box-shadow 120ms ease",
+              }}
+            >
+              {slot.faceUp && (
+                <>
+                  {/* Oval region vignette, like the printed region cards */}
+                  <Box
+                    sx={{
+                      width: 52,
+                      height: 58,
+                      borderRadius: "50%",
+                      border: `2px solid ${GOLD}`,
+                      background: `radial-gradient(circle at 42% 36%, ${color.fill}, ${color.edge})`,
+                      mb: "4px",
+                    }}
+                  />
+                  <Typography
+                    sx={{
+                      fontFamily: FONT_BODY,
+                      fontSize: "0.62rem",
+                      fontWeight: 700,
+                      lineHeight: 1,
+                      color: INK,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      maxWidth: "100%",
+                    }}
+                  >
+                    <Box component="span" sx={{ color: RUBRIC }}>
+                      {regionName(slot.regionId).charAt(0)}
+                    </Box>
+                    {regionName(slot.regionId).slice(1)}
+                  </Typography>
+                </>
+              )}
+              {slot.negotiationDisc && (
+                <Box
+                  sx={{
+                    position: "absolute",
+                    top: 4,
+                    right: 4,
+                    width: 16,
+                    height: 16,
+                    borderRadius: "50%",
+                    background: NEGOTIATION,
+                    border: `2px solid #9a8c6d`,
+                    boxShadow: "0 1px 2px rgba(0,0,0,0.4)",
+                  }}
+                  title="Negotiation disc"
+                />
+              )}
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export default RegionCardTrack;

--- a/src/features/tkid2/Tkid2Game.tsx
+++ b/src/features/tkid2/Tkid2Game.tsx
@@ -3,12 +3,10 @@ import {
   AppBar,
   Box,
   Button,
-  Chip,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   IconButton,
   Slide,
   Stack,
@@ -17,12 +15,10 @@ import {
   Toolbar,
   Tooltip,
   Typography,
-  useTheme,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import RefreshIcon from "@mui/icons-material/Refresh";
-import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import PersonIcon from "@mui/icons-material/Person";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
 import { TransitionProps } from "@mui/material/transitions";
@@ -30,26 +26,58 @@ import { Tkid2Logo } from "./Tkid2Logo";
 import { Difficulty } from "./ai/botPolicy";
 import { useTkid2BotDriver } from "./useTkid2BotDriver";
 import {
-  CrownOwner,
+  CARD_INFO,
+  CardId,
+  CardParams,
   FACTIONS,
+  FACTION_LABEL,
   Faction,
-  REGIONS,
-  RegionId,
-  TKID2Action,
-  TKID2State,
+  FactionCounts,
+  PlayerId,
+  Tkid2Action,
+  Tkid2Event,
+  Tkid2Player,
+  Tkid2State,
   applyAction,
-  cardById,
-  crownCounts,
+  contestedRegionId,
+  controlledCounts,
   currentPlayer,
-  currentRegionId,
-  decidingFaction,
+  enumerateCardParams,
+  gameResult,
   isGameOver,
-  isInvasion,
   newGame,
-  projectedOwner,
-  results,
-  winners,
+  regionName,
+  setCount,
+  summonOptions,
 } from "./engine/tkid2Engine";
+import {
+  CubeRef,
+  Selection,
+  cubeKey,
+  finalParams,
+  getTargets,
+  pickCube,
+  pickRegion,
+  pickSlot,
+  pickVariant,
+  startSelection,
+} from "./selection";
+import { BoardMap } from "./BoardMap";
+import { RegionCardTrack } from "./RegionCardTrack";
+import { ActionCardView } from "./ActionCardView";
+import {
+  CARD_BACK,
+  FACTION_COLOR,
+  FONT_BODY,
+  FONT_UNCIAL,
+  GOLD,
+  INK,
+  INK_FADED,
+  INSTABILITY,
+  PARCHMENT,
+  PARCHMENT_DARK,
+  RUBRIC,
+} from "./style";
 
 const Transition = React.forwardRef(function Transition(
   props: TransitionProps & { children: React.ReactElement },
@@ -58,28 +86,84 @@ const Transition = React.forwardRef(function Transition(
   return <Slide direction="up" ref={ref} {...props} />;
 });
 
-const FACTION_COLOR: Record<Faction, string> = {
-  english: "#9E9E9E",
-  scottish: "#4F86C6",
-  welsh: "#D65A5A",
-};
-const CROWN_COLOR: Record<CrownOwner, string> = {
-  ...FACTION_COLOR,
-  french: "#66A366",
-};
-const CROWN_LABEL: Record<CrownOwner, string> = {
-  english: "English",
-  scottish: "Scottish",
-  welsh: "Welsh",
-  french: "Foreign (revolt)",
-};
-const FACTION_LABEL: Record<Faction, string> = {
-  english: "English",
-  scottish: "Scottish",
-  welsh: "Welsh",
-};
-
 const HUMAN_ID = "human";
+
+// ===========================================================================
+// Small shared pieces
+// ===========================================================================
+
+function FactionCube({ faction, size = 15 }: { faction: Faction; size?: number }) {
+  const c = FACTION_COLOR[faction];
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        borderRadius: "3px",
+        background: `linear-gradient(145deg, ${c.light}, ${c.main} 60%)`,
+        border: `1.5px solid ${c.dark}`,
+        verticalAlign: "middle",
+      }}
+    />
+  );
+}
+
+function CourtCubes({ court }: { court: FactionCounts }) {
+  return (
+    <Stack direction="row" spacing={1.2} alignItems="center">
+      {FACTIONS.map((f) => (
+        <Stack key={f} direction="row" spacing={0.4} alignItems="center">
+          <FactionCube faction={f} />
+          <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.85rem", color: INK }}>
+            {court[f]}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+function ParchmentPanel({
+  children,
+  sx,
+}: {
+  children: React.ReactNode;
+  sx?: object;
+}) {
+  return (
+    <Box
+      sx={{
+        borderRadius: "8px",
+        border: `2px solid ${CARD_BACK}`,
+        outline: `1px solid ${GOLD}`,
+        outlineOffset: "-5px",
+        background: `linear-gradient(165deg, #f6eed6, ${PARCHMENT} 60%, ${PARCHMENT_DARK})`,
+        p: 1.5,
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function UncialHeading({ children, size = "1rem" }: { children: React.ReactNode; size?: string }) {
+  return (
+    <Typography
+      sx={{
+        fontFamily: FONT_UNCIAL,
+        fontSize: size,
+        color: RUBRIC,
+        letterSpacing: 0.5,
+        lineHeight: 1.2,
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
 
 // ===========================================================================
 // Setup screen
@@ -88,448 +172,344 @@ const HUMAN_ID = "human";
 interface SetupResult {
   botCount: number;
   difficulty: Difficulty;
+  advanced: boolean;
 }
 
 function SetupScreen({ onStart }: { onStart: (r: SetupResult) => void }) {
-  const [botCount, setBotCount] = React.useState(1);
+  const [botCount, setBotCount] = React.useState(2);
   const [difficulty, setDifficulty] = React.useState<Difficulty>("normal");
+  const [advanced, setAdvanced] = React.useState(false);
 
   return (
-    <Stack spacing={3} sx={{ maxWidth: 460, mx: "auto", mt: 2 }}>
-      <Typography variant="body1" color="text.secondary">
-        Vie for control of Britain. Play single-use action cards to sway each
-        region, and collect followers of the faction you think will end up on
-        top. If enough regions fall into revolt, a foreign invasion flips the
-        game — then the weakest faction's followers win.
-      </Typography>
-
-      <Box>
-        <Typography variant="subtitle2" gutterBottom>
-          AI opponents
+    <Stack spacing={2.5} sx={{ maxWidth: 520, mx: "auto", mt: 2, pb: 4 }}>
+      <Box sx={{ textAlign: "center" }}>
+        <Tkid2Logo size={84} />
+        <Typography sx={{ fontFamily: FONT_UNCIAL, fontSize: "1.9rem", color: RUBRIC, mt: 1 }}>
+          The King is Dead
         </Typography>
-        <ToggleButtonGroup
-          exclusive
-          color="primary"
-          value={botCount}
-          onChange={(_, v) => v && setBotCount(v)}
-        >
-          <ToggleButton value={1}>1 AI</ToggleButton>
-          <ToggleButton value={2}>2 AI</ToggleButton>
-        </ToggleButtonGroup>
+        <Typography sx={{ fontFamily: FONT_BODY, fontStyle: "italic", color: INK_FADED }}>
+          Second Edition · after Peer Sylvester
+        </Typography>
       </Box>
 
-      <Box>
-        <Typography variant="subtitle2" gutterBottom>
-          Difficulty
+      <ParchmentPanel>
+        <Typography sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.95rem" }}>
+          The king is dead and the kingdom is divided. Three factions — the{" "}
+          <b>Scottish</b>, the <b>Welsh</b>, and the <b>English</b> — vie for control
+          of eight regions of Britain. Play your eight action cards to steer each
+          power struggle, and summon followers to your court so the victorious
+          faction crowns <i>you</i>. But beware: too much instability, and the
+          French will invade…
         </Typography>
-        <ToggleButtonGroup
-          exclusive
-          color="primary"
-          value={difficulty}
-          onChange={(_, v) => v && setDifficulty(v)}
-        >
-          <ToggleButton value="easy">Easy</ToggleButton>
-          <ToggleButton value="normal">Normal</ToggleButton>
-          <ToggleButton value="godlike">Godlike</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
+      </ParchmentPanel>
+
+      <ParchmentPanel>
+        <Stack spacing={2}>
+          <Box>
+            <UncialHeading>Opponents</UncialHeading>
+            <ToggleButtonGroup
+              exclusive
+              value={botCount}
+              onChange={(_, v) => v && setBotCount(v)}
+              sx={{ mt: 0.5 }}
+            >
+              <ToggleButton value={1}>1 AI</ToggleButton>
+              <ToggleButton value={2}>2 AI</ToggleButton>
+              <ToggleButton value={3}>3 AI</ToggleButton>
+            </ToggleButtonGroup>
+            {botCount === 3 && (
+              <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.8rem", color: INK_FADED, mt: 0.5 }}>
+                Four players play in teams of two — the AI sitting opposite you is
+                your ally.
+              </Typography>
+            )}
+          </Box>
+          <Box>
+            <UncialHeading>Difficulty</UncialHeading>
+            <ToggleButtonGroup
+              exclusive
+              value={difficulty}
+              onChange={(_, v) => v && setDifficulty(v)}
+              sx={{ mt: 0.5 }}
+            >
+              <ToggleButton value="easy">Easy</ToggleButton>
+              <ToggleButton value="normal">Normal</ToggleButton>
+              <ToggleButton value="godlike">Godlike</ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+          <Box>
+            <UncialHeading>Rules</UncialHeading>
+            <ToggleButtonGroup
+              exclusive
+              value={advanced}
+              onChange={(_, v) => v !== null && setAdvanced(v)}
+              sx={{ mt: 0.5 }}
+            >
+              <ToggleButton value={false}>Basic game</ToggleButton>
+              <ToggleButton value={true}>Advanced (cunning cards)</ToggleButton>
+            </ToggleButtonGroup>
+            <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.8rem", color: INK_FADED, mt: 0.5 }}>
+              Advanced: the three Support cards are replaced by three secret
+              cunning action cards, dealt to each player.
+            </Typography>
+          </Box>
+        </Stack>
+      </ParchmentPanel>
 
       <Button
-        variant="contained"
         size="large"
-        onClick={() => onStart({ botCount, difficulty })}
+        onClick={() => onStart({ botCount, difficulty, advanced })}
+        sx={{
+          fontFamily: FONT_UNCIAL,
+          fontSize: "1.1rem",
+          color: "#fdf3d8",
+          background: `linear-gradient(180deg, #a13c30, ${CARD_BACK})`,
+          border: `2px solid #4a1812`,
+          "&:hover": { background: `linear-gradient(180deg, #b04b3e, #8e3a2e)` },
+          py: 1.2,
+        }}
       >
-        Start game
+        Begin the Struggle
       </Button>
     </Stack>
   );
 }
 
 // ===========================================================================
-// Board pieces
+// Player panels & chronicle
 // ===========================================================================
 
-function CubeRow({ cubes }: { cubes: Record<Faction, number> }) {
-  return (
-    <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ rowGap: 0.5 }}>
-      {FACTIONS.map((f) => (
-        <Chip
-          key={f}
-          size="small"
-          label={`${FACTION_LABEL[f]} ${cubes[f]}`}
-          sx={{
-            bgcolor: FACTION_COLOR[f],
-            color: "#111",
-            fontWeight: 700,
-            opacity: cubes[f] > 0 ? 1 : 0.35,
-          }}
-        />
-      ))}
-    </Stack>
-  );
-}
-
-function RegionCard({
+function PlayerPanel({
   state,
-  regionId,
+  player,
+  isTeammate,
 }: {
-  state: TKID2State;
-  regionId: RegionId;
+  state: Tkid2State;
+  player: Tkid2Player;
+  isTeammate: boolean;
 }) {
-  const def = REGIONS.find((r) => r.id === regionId)!;
-  const cubes = state.regions[regionId];
-  const crown = state.crowns[regionId];
-  const contested = currentRegionId(state) === regionId;
-  const projected = projectedOwner(cubes);
-
+  const onTurn = !isGameOver(state) && currentPlayer(state).id === player.id;
+  const topDiscard = player.discard[player.discard.length - 1];
   return (
     <Box
       sx={{
-        p: 1.5,
-        borderRadius: 2,
-        border: "2px solid",
-        borderColor: contested ? "primary.main" : "divider",
-        bgcolor: contested ? "rgba(176,124,243,0.10)" : "background.paper",
-        minWidth: 190,
-        flex: "1 1 190px",
-      }}
-    >
-      <Stack direction="row" alignItems="center" spacing={1}>
-        <Typography variant="subtitle1" sx={{ fontWeight: 700, flexGrow: 1 }}>
-          {def.name}
-        </Typography>
-        {crown && (
-          <Tooltip title={`Crown: ${CROWN_LABEL[crown]}`}>
-            <EmojiEventsIcon sx={{ color: CROWN_COLOR[crown] }} />
-          </Tooltip>
-        )}
-        {contested && !crown && (
-          <Chip
-            size="small"
-            label="Contested"
-            color="primary"
-            variant="outlined"
-          />
-        )}
-      </Stack>
-      {crown ? (
-        <Typography variant="caption" color="text.secondary">
-          Won by {CROWN_LABEL[crown]}
-        </Typography>
-      ) : (
-        <Stack spacing={0.5} sx={{ mt: 0.5 }}>
-          <CubeRow cubes={cubes} />
-          <Typography variant="caption" color="text.secondary">
-            {projected === "french"
-              ? "Currently: revolt (tie/empty)"
-              : `Currently leading: ${CROWN_LABEL[projected]}`}
-          </Typography>
-        </Stack>
-      )}
-    </Box>
-  );
-}
-
-function CourtRow({
-  state,
-  playerId,
-}: {
-  state: TKID2State;
-  playerId: string;
-}) {
-  const player = state.players.find((p) => p.id === playerId)!;
-  const onTurn = currentPlayer(state).id === playerId && !isGameOver(state);
-  return (
-    <Stack
-      direction="row"
-      spacing={1}
-      alignItems="center"
-      sx={{
-        p: 1,
-        borderRadius: 1.5,
-        border: "1px solid",
-        borderColor: onTurn ? "primary.main" : "divider",
-        bgcolor: onTurn ? "rgba(176,124,243,0.08)" : "transparent",
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        borderRadius: "6px",
+        border: `2px solid ${onTurn ? GOLD : "#c5ad7c"}`,
+        boxShadow: onTurn ? `0 0 8px ${GOLD}` : "none",
+        background: "rgba(255,252,240,0.5)",
+        px: 1,
+        py: 0.6,
       }}
     >
       {player.isBot ? (
-        <SmartToyIcon fontSize="small" />
+        <SmartToyIcon sx={{ fontSize: 18, color: INK_FADED }} />
       ) : (
-        <PersonIcon fontSize="small" />
+        <PersonIcon sx={{ fontSize: 18, color: INK_FADED }} />
       )}
-      <Typography variant="body2" sx={{ fontWeight: 700, minWidth: 90 }}>
-        {player.name}
-        {player.passed && !isGameOver(state) ? " (passed)" : ""}
-      </Typography>
-      <CubeRow cubes={player.court} />
-      <Box sx={{ flexGrow: 1 }} />
-      <Chip size="small" label={`${player.hand.length} cards`} variant="outlined" />
-    </Stack>
-  );
-}
-
-// ===========================================================================
-// Human controls
-// ===========================================================================
-
-function HumanControls({
-  state,
-  onAction,
-}: {
-  state: TKID2State;
-  onAction: (a: TKID2Action) => void;
-}) {
-  const [passOpen, setPassOpen] = React.useState(false);
-  const [manoeuvreCard, setManoeuvreCard] = React.useState<string | null>(null);
-
-  const region = currentRegionId(state);
-  const me = state.players.find((p) => p.id === HUMAN_ID);
-  if (!me || region === null || isGameOver(state)) return null;
-  const cubes = state.regions[region];
-  const myTurn = currentPlayer(state).id === HUMAN_ID && !me.passed;
-
-  if (!myTurn) {
-    return (
-      <Typography variant="body2" color="text.secondary">
-        {me.passed
-          ? "You have passed this round — waiting for opponents…"
-          : `Waiting for ${currentPlayer(state).name}…`}
-      </Typography>
-    );
-  }
-
-  const def = REGIONS.find((r) => r.id === region)!;
-  const takeable = FACTIONS.filter((f) => cubes[f] > 0);
-
-  return (
-    <Stack spacing={1.5}>
-      <Typography variant="subtitle2">Your turn — play a card or pass</Typography>
-      <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ rowGap: 1 }}>
-        {me.hand.map((cardId) => {
-          const card = cardById(cardId)!;
-          const disabled =
-            card.kind === "exile" &&
-            card.faction !== null &&
-            cubes[card.faction] <= 0;
-          return (
-            <Button
-              key={cardId}
-              size="small"
-              variant="outlined"
-              disabled={disabled}
-              onClick={() => {
-                if (card.kind === "manoeuvre") {
-                  setManoeuvreCard(cardId);
-                } else {
-                  onAction({ type: "playCard", cardId });
-                }
-              }}
-              sx={{
-                borderColor:
-                  card.faction !== null ? FACTION_COLOR[card.faction] : "text.secondary",
-                color: card.faction !== null ? FACTION_COLOR[card.faction] : "text.primary",
-              }}
-            >
-              {card.label}
-            </Button>
-          );
-        })}
-      </Stack>
-      <Box>
-        <Button variant="contained" color="secondary" onClick={() => setPassOpen(true)}>
-          Pass{takeable.length > 0 ? " & take a follower" : ""}
-        </Button>
+      <Box sx={{ minWidth: 76 }}>
+        <Typography sx={{ fontFamily: FONT_BODY, fontWeight: 700, fontSize: "0.9rem", color: INK, lineHeight: 1.1 }}>
+          {player.name}
+          {isTeammate ? " ♥" : ""}
+        </Typography>
+        <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.72rem", color: INK_FADED }}>
+          {player.hand.length} card{player.hand.length === 1 ? "" : "s"} · sets {setCount(player.court)}
+        </Typography>
       </Box>
-
-      {/* Pass / take-follower dialog */}
-      <Dialog open={passOpen} onClose={() => setPassOpen(false)}>
-        <DialogTitle>Pass this round</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            Take one follower into your court, then sit out the rest of this
-            round.
-          </Typography>
-          <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ rowGap: 1, mt: 1 }}>
-            {takeable.map((f) => (
-              <Button
-                key={f}
-                variant="contained"
-                onClick={() => {
-                  onAction({ type: "pass", takeFollower: f });
-                  setPassOpen(false);
-                }}
-                sx={{ bgcolor: FACTION_COLOR[f], color: "#111" }}
-              >
-                Take {FACTION_LABEL[f]}
-              </Button>
-            ))}
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => {
-              onAction({ type: "pass" });
-              setPassOpen(false);
-            }}
-          >
-            {takeable.length > 0 ? "Take nothing" : "Pass"}
-          </Button>
-          <Button onClick={() => setPassOpen(false)}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Manoeuvre source picker */}
-      <Dialog open={manoeuvreCard !== null} onClose={() => setManoeuvreCard(null)}>
-        <DialogTitle>Manoeuvre into {def.name}</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            Move a faction's cubes in from a neighbouring region.
-          </Typography>
-          <Stack spacing={1.5} sx={{ mt: 1 }}>
-            {def.adjacent.map((adj) => {
-              const adjDef = REGIONS.find((r) => r.id === adj)!;
-              const adjCubes = state.regions[adj];
-              const present = FACTIONS.filter((f) => adjCubes[f] > 0);
-              return (
-                <Box key={adj}>
-                  <Typography variant="caption" color="text.secondary">
-                    From {adjDef.name}
-                  </Typography>
-                  <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ rowGap: 1 }}>
-                    {present.length === 0 && (
-                      <Typography variant="caption" color="text.disabled">
-                        (no cubes)
-                      </Typography>
-                    )}
-                    {present.map((f) => (
-                      <Button
-                        key={f}
-                        size="small"
-                        variant="contained"
-                        onClick={() => {
-                          onAction({
-                            type: "playCard",
-                            cardId: manoeuvreCard!,
-                            fromRegion: adj,
-                            faction: f,
-                          });
-                          setManoeuvreCard(null);
-                        }}
-                        sx={{ bgcolor: FACTION_COLOR[f], color: "#111" }}
-                      >
-                        {FACTION_LABEL[f]} ({adjCubes[f]})
-                      </Button>
-                    ))}
-                  </Stack>
-                </Box>
-              );
-            })}
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setManoeuvreCard(null)}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
-    </Stack>
-  );
-}
-
-// ===========================================================================
-// End-of-game summary
-// ===========================================================================
-
-function GameOverPanel({ state }: { state: TKID2State }) {
-  const ranked = results(state);
-  const won = winners(state);
-  const wonIds = new Set(won.map((w) => w.playerId));
-  const invasion = isInvasion(state);
-  const deciding = decidingFaction(state);
-  const counts = crownCounts(state);
-
-  return (
-    <Box
-      sx={{
-        p: 2,
-        borderRadius: 2,
-        border: "2px solid",
-        borderColor: "primary.main",
-        bgcolor: "rgba(176,124,243,0.10)",
-      }}
-    >
-      <Typography variant="h6" gutterBottom>
-        {invasion ? "Foreign invasion!" : "The realm is united"}
-      </Typography>
-      <Typography variant="body2" color="text.secondary" gutterBottom>
-        {invasion
-          ? `Too many regions fell into revolt (${counts.french}). Alignment with the weakest faction, ${CROWN_LABEL[deciding]}, decides the winner.`
-          : `The ${CROWN_LABEL[deciding]} faction is strongest. Whoever has the most ${FACTION_LABEL[deciding]} followers wins.`}
-      </Typography>
-      <Divider sx={{ my: 1 }} />
-      <Stack spacing={1}>
-        {ranked.map((r, i) => (
-          <Stack key={r.playerId} direction="row" alignItems="center" spacing={1}>
-            {wonIds.has(r.playerId) ? (
-              <EmojiEventsIcon sx={{ color: "#F4C947" }} />
-            ) : (
-              <Typography sx={{ width: 24, textAlign: "center" }}>{i + 1}</Typography>
-            )}
-            <Typography sx={{ fontWeight: wonIds.has(r.playerId) ? 700 : 400, flexGrow: 1 }}>
-              {r.name}
-            </Typography>
-            <Chip
-              size="small"
-              label={`${r.score} ${FACTION_LABEL[deciding]}`}
-              sx={{ bgcolor: FACTION_COLOR[deciding], color: "#111", fontWeight: 700 }}
-            />
-          </Stack>
-        ))}
-      </Stack>
+      <CourtCubes court={player.court} />
+      <Box sx={{ flexGrow: 1 }} />
+      {topDiscard ? (
+        <Tooltip title={`Last played: ${CARD_INFO[topDiscard].name}`}>
+          <Box>
+            <ActionCardView cardId={topDiscard} small />
+          </Box>
+        </Tooltip>
+      ) : (
+        <Box sx={{ width: 74 }} />
+      )}
     </Box>
   );
 }
 
+function describeEvents(events: Tkid2Event[], state: Tkid2State): string[] {
+  const name = (id: PlayerId) => state.players.find((p) => p.id === id)?.name ?? id;
+  const lines: string[] = [];
+  for (const e of events) {
+    switch (e.kind) {
+      case "played":
+        lines.push(
+          e.viaSpy
+            ? `${name(e.playerId)} copied ${CARD_INFO[e.cardId].name} with Spy.`
+            : `${name(e.playerId)} played ${CARD_INFO[e.cardId].name}.`,
+        );
+        break;
+      case "summoned":
+        lines.push(
+          `${name(e.playerId)} summoned a ${FACTION_LABEL[e.faction]} follower from ${regionName(e.regionId)}.`,
+        );
+        break;
+      case "summonSkipped":
+        lines.push(`${name(e.playerId)} could not summon a follower.`);
+        break;
+      case "passed":
+        lines.push(`${name(e.playerId)} passed.`);
+        break;
+      case "struggle":
+        lines.push(
+          e.record.outcome === "unstable"
+            ? `⚑ ${regionName(e.record.regionId)} fell into instability!`
+            : `⚑ The ${FACTION_LABEL[e.record.outcome]} took control of ${regionName(e.record.regionId)}.`,
+        );
+        break;
+      case "invasion":
+        lines.push("⚜ The French invade Britain — the game ends!");
+        break;
+      case "coronation":
+        lines.push("♔ Every region is decided — a new ruler is crowned!");
+        break;
+    }
+  }
+  return lines;
+}
+
 // ===========================================================================
-// Rules help
+// Game over
+// ===========================================================================
+
+function GameOverPanel({ state, onAgain }: { state: Tkid2State; onAgain: () => void }) {
+  const result = gameResult(state);
+  if (!result) return null;
+  const invasion = result.ending === "invasion";
+  const ranked = [...result.results].sort(
+    (a, b) => Number(b.winner) - Number(a.winner) || b.score - a.score || b.secondary - a.secondary,
+  );
+  return (
+    <ParchmentPanel sx={{ textAlign: "center" }}>
+      <UncialHeading size="1.5rem">{invasion ? "Invasion" : "Coronation"}</UncialHeading>
+      <Typography sx={{ fontFamily: FONT_BODY, fontStyle: "italic", color: INK_FADED, mb: 1 }}>
+        {invasion
+          ? "The French invade Britain. The leader who can unite the factions will claim the throne."
+          : "The struggle for power comes to an end, and a new monarch is crowned."}
+      </Typography>
+
+      {!invasion && (
+        <Stack direction="row" spacing={2} justifyContent="center" sx={{ mb: 1.5 }}>
+          {result.standings.map((s, i) => (
+            <Stack key={s.faction} alignItems="center" spacing={0.3}>
+              <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.75rem", color: INK_FADED }}>
+                {i + 1}
+              </Typography>
+              <Box
+                sx={{
+                  width: 34,
+                  height: 34,
+                  borderRadius: "50%",
+                  background: FACTION_COLOR[s.faction].main,
+                  border: `3px solid ${FACTION_COLOR[s.faction].dark}`,
+                }}
+              />
+              <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.75rem", color: INK }}>
+                {FACTION_LABEL[s.faction]} · {s.regions}
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      )}
+
+      <Stack spacing={0.6} sx={{ maxWidth: 420, mx: "auto" }}>
+        {ranked.map((r) => (
+          <Stack key={r.playerId} direction="row" spacing={1} alignItems="center">
+            <Typography sx={{ width: 26, fontSize: "1.1rem" }}>{r.winner ? "♔" : ""}</Typography>
+            <Typography
+              sx={{
+                fontFamily: FONT_BODY,
+                fontWeight: r.winner ? 700 : 400,
+                color: INK,
+                flexGrow: 1,
+                textAlign: "left",
+              }}
+            >
+              {r.name}
+              {r.plot ? " (Plot)" : ""}
+            </Typography>
+            <Typography sx={{ fontFamily: FONT_BODY, color: INK }}>
+              {invasion
+                ? `${r.score} set${r.score === 1 ? "" : "s"}`
+                : `${r.score} ${FACTION_LABEL[result.standings[0].faction]}`}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+      {result.teams && (
+        <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.8rem", color: INK_FADED, mt: 1 }}>
+          Teammates share the victory — the uncrowned ally becomes the power behind the throne.
+        </Typography>
+      )}
+      <Button
+        onClick={onAgain}
+        sx={{
+          mt: 1.5,
+          fontFamily: FONT_UNCIAL,
+          color: "#fdf3d8",
+          background: `linear-gradient(180deg, #a13c30, ${CARD_BACK})`,
+          px: 3,
+          "&:hover": { background: "#8e3a2e" },
+        }}
+      >
+        Play again
+      </Button>
+    </ParchmentPanel>
+  );
+}
+
+// ===========================================================================
+// Rules dialog
 // ===========================================================================
 
 function RulesDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>How to play — The King Is Dead</DialogTitle>
-      <DialogContent dividers>
+      <DialogTitle sx={{ fontFamily: FONT_UNCIAL, color: RUBRIC }}>
+        How to play
+      </DialogTitle>
+      <DialogContent dividers sx={{ fontFamily: FONT_BODY }}>
         <Typography variant="body2" paragraph>
-          Regions of Britain are contested one at a time. On your turn you either
-          play one single-use <b>action card</b> or <b>pass</b>.
+          On your turn, either <b>take an action</b> (play one of your eight
+          single-use action cards and resolve its effect) or <b>pass</b>. After
+          taking an action you <b>must summon a follower</b>: take any one
+          follower cube from any region into your court.
         </Typography>
-        <Typography variant="body2" component="div">
-          <ul style={{ margin: 0, paddingLeft: 18 }}>
-            <li>
-              <b>Muster</b> — add cubes of a faction to the contested region.
-            </li>
-            <li>
-              <b>Exile</b> — remove cubes of a faction from the contested region.
-            </li>
-            <li>
-              <b>Manoeuvre</b> — move a faction's cubes in from a neighbouring
-              region.
-            </li>
-            <li>
-              <b>Pass</b> — take one follower (a cube of your choice present in
-              the region) into your court, then sit out the rest of the round.
-            </li>
-          </ul>
+        <Typography variant="body2" paragraph>
+          When all players pass in sequence, a <b>power struggle</b> is resolved
+          in the contested region — the region card in the lowest-numbered space
+          that is still face up. The faction with the most followers there takes
+          control (its control disc is placed), and all followers in the region
+          return to the supply. A tie — or an empty region — makes the region{" "}
+          <b>unstable</b>, and an instability disc moves there from France.
         </Typography>
-        <Typography variant="body2" paragraph sx={{ mt: 1 }}>
-          When everyone has passed, the region's majority faction earns its
-          crown; a tie leaves the region in revolt (a foreign crown). After all
-          regions resolve, the strongest faction decides the winner — the player
-          with the most followers of that faction. But if enough regions fell
-          into revolt, a foreign invasion flips it: the <i>weakest</i> faction's
-          followers win instead.
+        <Typography variant="body2" paragraph>
+          You can never place or move followers into regions that already have a
+          control or instability disc.
         </Typography>
-        <Typography variant="caption" color="text.secondary">
-          Note: exact rulebook values are an interpretation and may differ from
-          the published game.
+        <Typography variant="body2" paragraph>
+          <b>The game ends</b> when the third instability disc reaches the board
+          (a <b>French invasion</b>: the player with the most complete sets of
+          followers — one of each faction — wins) or when all eight regions are
+          decided (a <b>coronation</b>: the player with the most followers of
+          the most powerful faction in court wins; the most powerful faction is
+          the one controlling the most regions, ties broken by the most recent
+          power-struggle win).
+        </Typography>
+        <Typography variant="body2" paragraph>
+          Followers in your court crown you — but every follower you summon is
+          one fewer fighting for that faction on the board.
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          Hover or long-press any card to read its exact effect. In the advanced
+          game the three Support cards are replaced by three secret cunning
+          action cards.
         </Typography>
       </DialogContent>
       <DialogActions>
@@ -540,14 +520,33 @@ function RulesDialog({ open, onClose }: { open: boolean; onClose: () => void }) 
 }
 
 // ===========================================================================
-// Root game component
+// Root component
 // ===========================================================================
 
 export function Tkid2Game({ onExit }: { onExit: () => void }) {
-  const theme = useTheme();
-  const [state, setState] = React.useState<TKID2State | null>(null);
+  const [state, setState] = React.useState<Tkid2State | null>(null);
   const [config, setConfig] = React.useState<SetupResult | null>(null);
+  const [selection, setSelection] = React.useState<Selection | null>(null);
+  const [log, setLog] = React.useState<string[]>([]);
   const [showHelp, setShowHelp] = React.useState(false);
+  const [spyOpen, setSpyOpen] = React.useState(false);
+  const [confirmNoEffect, setConfirmNoEffect] = React.useState<CardId | null>(null);
+  const [notice, setNotice] = React.useState<string | null>(null);
+
+  const stateRef = React.useRef(state);
+  stateRef.current = state;
+
+  const applyLocal = React.useCallback((action: Tkid2Action) => {
+    const prev = stateRef.current;
+    if (!prev) return;
+    const res = applyAction(prev, action);
+    if (res.error) {
+      setNotice(res.error);
+      return;
+    }
+    setState(res.state);
+    setLog((l) => [...describeEvents(res.events, prev).reverse(), ...l].slice(0, 24));
+  }, []);
 
   const start = (r: SetupResult) => {
     const players = [
@@ -558,24 +557,31 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
         isBot: true,
       })),
     ];
-    // Non-negative 31-bit seed from the clock for a fresh, reproducible game.
     const seed = Date.now() & 0x7fffffff;
-    setState(newGame(players, seed));
+    setState(newGame(players, seed, { advanced: r.advanced }));
     setConfig(r);
+    setSelection(null);
+    setLog([]);
   };
 
-  const applyLocal = React.useCallback((action: TKID2Action) => {
-    setState((prev) => {
-      if (!prev) return prev;
-      const res = applyAction(prev, action);
-      // Silently ignore rejected actions (shouldn't happen from valid UI/AI).
-      return res.error ? prev : res.state;
-    });
-  }, []);
+  const reset = () => {
+    setState(null);
+    setConfig(null);
+    setSelection(null);
+    setLog([]);
+  };
+
+  // Auto-clear notices.
+  React.useEffect(() => {
+    if (!notice) return;
+    const t = setTimeout(() => setNotice(null), 3500);
+    return () => clearTimeout(t);
+  }, [notice]);
 
   const botIds = React.useMemo(
     () => state?.players.filter((p) => p.isBot).map((p) => p.id) ?? [],
-    [state],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [state?.players.length],
   );
   const difficultyById = React.useMemo(() => {
     const map: Record<string, Difficulty> = {};
@@ -592,30 +598,134 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
   });
 
   const gameOver = state !== null && isGameOver(state);
+  const contested = state ? contestedRegionId(state) : null;
+  const human = state?.players.find((p) => p.id === HUMAN_ID);
+  const humanTurn =
+    !!state && !gameOver && currentPlayer(state).id === HUMAN_ID;
+  const humanSummon = humanTurn && !!state && state.pendingSummon;
+
+  const targets = React.useMemo(
+    () => (selection ? getTargets(selection) : null),
+    [selection],
+  );
+
+  // Dispatch a completed selection.
+  React.useEffect(() => {
+    if (selection && targets?.done) {
+      applyLocal({
+        type: "play",
+        cardId: selection.cardId,
+        params: finalParams(selection, targets.done),
+      });
+      setSelection(null);
+    }
+  }, [selection, targets, applyLocal]);
+
+  const highlightRegions = React.useMemo(() => {
+    if (selection && targets?.regions) return new Set(targets.regions);
+    return undefined;
+  }, [selection, targets]);
+
+  const highlightCubes = React.useMemo(() => {
+    if (selection && targets?.cubes) return new Set(targets.cubes.map(cubeKey));
+    if (humanSummon && state) return new Set(summonOptions(state).map(cubeKey));
+    return undefined;
+  }, [selection, targets, humanSummon, state]);
+
+  const highlightSlots = React.useMemo(() => {
+    if (selection && targets?.slots) return new Set(targets.slots);
+    return undefined;
+  }, [selection, targets]);
+
+  const onCardClick = (cardId: CardId) => {
+    if (!state || !humanTurn || state.pendingSummon || selection) return;
+    if (cardId === "plot") {
+      setNotice("Plot cannot be taken during the game — it is revealed when the winner is decided.");
+      return;
+    }
+    if (cardId === "spy") {
+      const opts = enumerateCardParams(state, "spy");
+      if (opts.length === 0) {
+        setConfirmNoEffect("spy");
+      } else {
+        setSpyOpen(true);
+      }
+      return;
+    }
+    const opts = enumerateCardParams(state, cardId);
+    if (opts.length === 0) {
+      setConfirmNoEffect(cardId);
+    } else {
+      setSelection(startSelection(cardId, opts));
+    }
+  };
+
+  const onRegionClick = (regionId: Parameters<typeof pickRegion>[1]) => {
+    if (selection) setSelection((s) => (s ? pickRegion(s, regionId) : s));
+  };
+
+  const onCubeClick = (cube: CubeRef) => {
+    if (!state || !humanTurn) return;
+    if (selection) {
+      setSelection((s) => (s ? pickCube(s, cube) : s));
+      return;
+    }
+    if (humanSummon) {
+      applyLocal({ type: "summon", regionId: cube.regionId, faction: cube.faction });
+    }
+  };
+
+  const onSlotClick = (position: number) => {
+    if (selection) setSelection((s) => (s ? pickSlot(s, position) : s));
+  };
+
+  const spyGroups = React.useMemo(() => {
+    if (!state || !spyOpen) return [];
+    const opts = enumerateCardParams(state, "spy");
+    const map = new Map<PlayerId, CardParams[]>();
+    for (const o of opts) {
+      if (!o.spyPlayerId) continue;
+      const list = map.get(o.spyPlayerId) ?? [];
+      list.push(o.spyParams ?? {});
+      map.set(o.spyPlayerId, list);
+    }
+    return Array.from(map.entries()).map(([playerId, inner]) => {
+      const target = state.players.find((p) => p.id === playerId)!;
+      return { playerId, name: target.name, top: target.discard[target.discard.length - 1], inner };
+    });
+  }, [state, spyOpen]);
+
+  const counts = state ? controlledCounts(state) : null;
+
+  // ------------------------------------------------------------------
+  // Prompt banner content
+  // ------------------------------------------------------------------
+  let prompt: string | null = null;
+  if (state && !gameOver) {
+    if (selection && targets && !targets.done) prompt = targets.prompt;
+    else if (humanSummon) prompt = "Summon a follower to your court — tap any follower on the map.";
+    else if (humanTurn) prompt = "Your turn — play a card or pass.";
+    else prompt = `Waiting for ${currentPlayer(state).name}…`;
+  }
 
   return (
     <Dialog fullScreen open onClose={onExit} TransitionComponent={Transition as any}>
       <AppBar
         sx={{
-          background: theme.palette.mode === "dark" ? "#2E1B47" : "#5B2E93",
           position: "relative",
+          background: `linear-gradient(180deg, #8e3a2e, ${CARD_BACK})`,
+          borderBottom: `3px solid ${GOLD}`,
         }}
       >
         <Toolbar>
-          <Tkid2Logo size={32} sx={{ marginRight: 8 }} />
-          <Typography variant="h6" sx={{ flex: 1, color: "#fff", fontWeight: 600 }}>
-            The King Is Dead
+          <Tkid2Logo size={34} sx={{ marginRight: 10 }} />
+          <Typography
+            sx={{ flex: 1, color: "#fdf3d8", fontFamily: FONT_UNCIAL, fontSize: "1.25rem" }}
+          >
+            The King is Dead
           </Typography>
           {state && (
-            <Button
-              color="inherit"
-              startIcon={<RefreshIcon />}
-              onClick={() => {
-                setState(null);
-                setConfig(null);
-              }}
-              sx={{ mr: 1 }}
-            >
+            <Button color="inherit" startIcon={<RefreshIcon />} onClick={reset} sx={{ mr: 1, fontFamily: FONT_BODY }}>
               New
             </Button>
           )}
@@ -623,7 +733,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
             color="inherit"
             startIcon={<HelpOutlineIcon />}
             onClick={() => setShowHelp(true)}
-            sx={{ mr: 1 }}
+            sx={{ mr: 1, fontFamily: FONT_BODY }}
           >
             Rules
           </Button>
@@ -633,69 +743,298 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
         </Toolbar>
       </AppBar>
 
-      <DialogContent sx={{ p: 2 }}>
+      <DialogContent
+        sx={{
+          p: { xs: 1, sm: 2 },
+          background: `radial-gradient(ellipse at 50% 20%, #f4ead0 0%, ${PARCHMENT} 55%, ${PARCHMENT_DARK} 100%)`,
+        }}
+      >
         {!state && <SetupScreen onStart={start} />}
 
         {state && (
-          <Stack spacing={2} sx={{ maxWidth: 900, mx: "auto" }}>
-            {/* Progress */}
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ rowGap: 1 }}>
-              <Chip
-                size="small"
-                label={`Region ${Math.min(state.eventIndex + 1, REGIONS.length)} / ${REGIONS.length}`}
-                color="primary"
-              />
-              {FACTIONS.map((f) => (
-                <Chip
-                  key={f}
-                  size="small"
-                  label={`${FACTION_LABEL[f]}: ${crownCounts(state)[f]} 👑`}
-                  sx={{ bgcolor: FACTION_COLOR[f], color: "#111", fontWeight: 700 }}
+          <Stack spacing={1.5} sx={{ maxWidth: 1200, mx: "auto", pb: 2 }}>
+            {/* Status strip */}
+            <Stack
+              direction="row"
+              spacing={1.5}
+              alignItems="center"
+              flexWrap="wrap"
+              useFlexGap
+              sx={{ rowGap: 0.5, justifyContent: "center" }}
+            >
+              <Typography sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.9rem" }}>
+                Struggle{" "}
+                <b>
+                  {Math.min(state.struggles.length + 1, 8)}
+                </b>{" "}
+                of 8
+              </Typography>
+              {contested && (
+                <Typography sx={{ fontFamily: FONT_BODY, color: RUBRIC, fontSize: "0.9rem" }}>
+                  ⚔ {regionName(contested)}
+                </Typography>
+              )}
+              {counts &&
+                FACTIONS.map((f) => (
+                  <Stack key={f} direction="row" spacing={0.4} alignItems="center">
+                    <Box
+                      sx={{
+                        width: 14,
+                        height: 14,
+                        borderRadius: "50%",
+                        background: FACTION_COLOR[f].main,
+                        border: `2px solid ${FACTION_COLOR[f].dark}`,
+                      }}
+                    />
+                    <Typography sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.9rem" }}>
+                      {counts[f]}
+                    </Typography>
+                  </Stack>
+                ))}
+              <Stack direction="row" spacing={0.4} alignItems="center">
+                <Box
+                  sx={{
+                    width: 14,
+                    height: 14,
+                    borderRadius: "50%",
+                    background: INSTABILITY,
+                    border: "2px solid #2b1e12",
+                  }}
                 />
-              ))}
-              <Chip
-                size="small"
-                label={`Revolt: ${crownCounts(state).french}`}
-                sx={{ bgcolor: CROWN_COLOR.french, color: "#111", fontWeight: 700 }}
-              />
+                <Typography sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.9rem" }}>
+                  {3 - state.instabilityInFrance}/3
+                </Typography>
+              </Stack>
             </Stack>
 
-            {gameOver && <GameOverPanel state={state} />}
+            {gameOver && <GameOverPanel state={state} onAgain={reset} />}
 
-            {/* Regions board */}
-            <Box>
-              <Typography variant="overline" color="text.secondary">
-                Regions
-              </Typography>
-              <Stack direction="row" flexWrap="wrap" gap={1.5}>
-                {state.eventOrder.map((rid) => (
-                  <RegionCard key={rid} state={state} regionId={rid} />
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "flex-start" }}>
+              {/* Map column */}
+              <Box sx={{ flex: "1 1 380px", maxWidth: 640, mx: "auto" }}>
+                <Box sx={{ mb: 1 }}>
+                  <RegionCardTrack
+                    state={state}
+                    contested={contested}
+                    highlightSlots={highlightSlots}
+                    pickedSlots={selection?.slotsPicked}
+                    onSlotClick={onSlotClick}
+                  />
+                </Box>
+                <Box
+                  sx={{
+                    borderRadius: "10px",
+                    border: `3px solid ${CARD_BACK}`,
+                    outline: `1.5px solid ${GOLD}`,
+                    outlineOffset: "-7px",
+                    overflow: "hidden",
+                    boxShadow: "0 4px 14px rgba(40,20,10,0.35)",
+                  }}
+                >
+                  <BoardMap
+                    state={state}
+                    contested={contested}
+                    highlightRegions={highlightRegions}
+                    highlightCubes={highlightCubes}
+                    pickedCubes={selection?.cubesPicked}
+                    onRegionClick={onRegionClick}
+                    onCubeClick={onCubeClick}
+                  />
+                </Box>
+              </Box>
+
+              {/* Side column: courts & chronicle */}
+              <Stack spacing={1} sx={{ flex: "1 1 300px", minWidth: 280 }}>
+                <UncialHeading>Courts</UncialHeading>
+                {state.players.map((p, i) => (
+                  <PlayerPanel
+                    key={p.id}
+                    state={state}
+                    player={p}
+                    isTeammate={
+                      state.players.length === 4 &&
+                      p.id !== HUMAN_ID &&
+                      state.players[(state.players.findIndex((q) => q.id === HUMAN_ID) + 2) % 4].id === p.id
+                    }
+                  />
                 ))}
+                <UncialHeading>Chronicle</UncialHeading>
+                <ParchmentPanel sx={{ p: 1, maxHeight: 190, overflowY: "auto" }}>
+                  {log.length === 0 && (
+                    <Typography sx={{ fontFamily: FONT_BODY, fontStyle: "italic", color: INK_FADED, fontSize: "0.82rem" }}>
+                      The chronicle of the struggle will be written here…
+                    </Typography>
+                  )}
+                  {log.map((line, i) => (
+                    <Typography
+                      key={`${i}-${line}`}
+                      sx={{
+                        fontFamily: FONT_BODY,
+                        fontSize: "0.82rem",
+                        color: i === 0 ? INK : INK_FADED,
+                        lineHeight: 1.45,
+                      }}
+                    >
+                      {line}
+                    </Typography>
+                  ))}
+                </ParchmentPanel>
               </Stack>
             </Box>
 
-            {/* Courts */}
-            <Box>
-              <Typography variant="overline" color="text.secondary">
-                Courts
-              </Typography>
-              <Stack spacing={1}>
-                {state.players.map((p) => (
-                  <CourtRow key={p.id} state={state} playerId={p.id} />
-                ))}
-              </Stack>
-            </Box>
+            {/* Prompt + hand (sticky at the bottom) */}
+            {!gameOver && human && (
+              <Box
+                sx={{
+                  position: "sticky",
+                  bottom: 0,
+                  zIndex: 5,
+                  mx: -1,
+                  px: 1,
+                  pt: 0.5,
+                  pb: 1,
+                  background: `linear-gradient(180deg, rgba(240,227,192,0), ${PARCHMENT} 22%)`,
+                }}
+              >
+                <ParchmentPanel sx={{ p: 1, mb: 1 }}>
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    alignItems="center"
+                    flexWrap="wrap"
+                    useFlexGap
+                    sx={{ rowGap: 0.5 }}
+                  >
+                    <Typography
+                      sx={{
+                        fontFamily: FONT_BODY,
+                        color: notice ? RUBRIC : INK,
+                        fontSize: "0.92rem",
+                        flexGrow: 1,
+                        fontStyle: humanTurn ? "normal" : "italic",
+                      }}
+                    >
+                      {notice ?? prompt}
+                    </Typography>
+                    {selection &&
+                      targets?.variants?.map((v, i) => (
+                        <Button
+                          key={`${v.label}-${i}`}
+                          size="small"
+                          variant="outlined"
+                          onClick={() => setSelection((s) => (s ? pickVariant(s, v.params) : s))}
+                          sx={{ fontFamily: FONT_BODY, color: INK, borderColor: INK_FADED, textTransform: "none" }}
+                        >
+                          {v.label}
+                        </Button>
+                      ))}
+                    {selection && (
+                      <Button
+                        size="small"
+                        onClick={() => setSelection(null)}
+                        sx={{ fontFamily: FONT_BODY, color: RUBRIC, textTransform: "none" }}
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                    {humanTurn && !state.pendingSummon && !selection && (
+                      <Button
+                        size="small"
+                        variant="contained"
+                        onClick={() => applyLocal({ type: "pass" })}
+                        sx={{
+                          fontFamily: FONT_UNCIAL,
+                          background: `linear-gradient(180deg, #a13c30, ${CARD_BACK})`,
+                          color: "#fdf3d8",
+                          "&:hover": { background: "#8e3a2e" },
+                        }}
+                      >
+                        Pass
+                      </Button>
+                    )}
+                  </Stack>
+                </ParchmentPanel>
 
-            {/* Human controls */}
-            {!gameOver && (
-              <>
-                <Divider />
-                <HumanControls state={state} onAction={applyLocal} />
-              </>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ overflowX: "auto", pb: 0.5, justifyContent: { xs: "flex-start", md: "center" } }}
+                >
+                  {human.hand.map((cardId) => (
+                    <ActionCardView
+                      key={cardId}
+                      cardId={cardId}
+                      selected={selection?.cardId === cardId}
+                      disabled={
+                        !humanTurn || state.pendingSummon || (!!selection && selection.cardId !== cardId)
+                      }
+                      onClick={() => onCardClick(cardId)}
+                    />
+                  ))}
+                  {human.hand.length === 0 && (
+                    <Typography sx={{ fontFamily: FONT_BODY, fontStyle: "italic", color: INK_FADED }}>
+                      You have played all your action cards — you can only pass now.
+                    </Typography>
+                  )}
+                </Stack>
+              </Box>
             )}
           </Stack>
         )}
       </DialogContent>
+
+      {/* Spy target dialog */}
+      <Dialog open={spyOpen} onClose={() => setSpyOpen(false)}>
+        <DialogTitle sx={{ fontFamily: FONT_UNCIAL, color: RUBRIC }}>Spy</DialogTitle>
+        <DialogContent>
+          <Typography sx={{ fontFamily: FONT_BODY, mb: 1.5 }} variant="body2">
+            Resolve the card on top of another player's discard pile:
+          </Typography>
+          <Stack direction="row" spacing={2}>
+            {spyGroups.map((g) => (
+              <Stack key={g.playerId} alignItems="center" spacing={0.5}>
+                <ActionCardView
+                  cardId={g.top!}
+                  onClick={() => {
+                    setSpyOpen(false);
+                    setSelection(startSelection("spy", g.inner, { playerId: g.playerId, effectiveCardId: g.top! }));
+                  }}
+                />
+                <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.8rem" }}>{g.name}</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSpyOpen(false)}>Cancel</Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* No-effect confirmation */}
+      <Dialog open={confirmNoEffect !== null} onClose={() => setConfirmNoEffect(null)}>
+        <DialogTitle sx={{ fontFamily: FONT_UNCIAL, color: RUBRIC }}>
+          {confirmNoEffect ? CARD_INFO[confirmNoEffect].name : ""}
+        </DialogTitle>
+        <DialogContent>
+          <Typography sx={{ fontFamily: FONT_BODY }} variant="body2">
+            This card currently has no possible effect. You may still play it —
+            you will summon a follower to your court as usual.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmNoEffect(null)}>Cancel</Button>
+          <Button
+            onClick={() => {
+              if (confirmNoEffect) {
+                applyLocal({ type: "play", cardId: confirmNoEffect, params: {} });
+              }
+              setConfirmNoEffect(null);
+            }}
+          >
+            Play it anyway
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <RulesDialog open={showHelp} onClose={() => setShowHelp(false)} />
     </Dialog>

--- a/src/features/tkid2/Tkid2Logo.tsx
+++ b/src/features/tkid2/Tkid2Logo.tsx
@@ -6,7 +6,10 @@ interface Props {
   className?: string;
 }
 
-/** A stylised crown for "The King Is Dead" in the game's purple palette. */
+/**
+ * The heraldic shield from the second-edition cover: per bend red and blue
+ * with a white bend and three gold crowns.
+ */
 export const Tkid2Logo: React.FC<Props> = ({ size = 40, sx, className }) => (
   <svg
     width={size}
@@ -18,20 +21,46 @@ export const Tkid2Logo: React.FC<Props> = ({ size = 40, sx, className }) => (
     aria-label="The King Is Dead"
     role="img"
   >
-    {/* Crown body */}
+    <defs>
+      <clipPath id="tkid2-shield">
+        <path d="M 12 8 L 52 8 C 53.5 9.5 54 11 54 13 L 54 34 C 54 47 45 54 32 59 C 19 54 10 47 10 34 L 10 13 C 10 11 10.5 9.5 12 8 Z" />
+      </clipPath>
+    </defs>
+    {/* Blue field */}
     <path
-      d="M10 44 L8 22 L22 34 L32 16 L42 34 L56 22 L54 44 Z"
-      fill="#B07CF3"
-      stroke="#5B2E93"
+      d="M 12 8 L 52 8 C 53.5 9.5 54 11 54 13 L 54 34 C 54 47 45 54 32 59 C 19 54 10 47 10 34 L 10 13 C 10 11 10.5 9.5 12 8 Z"
+      fill="#2f4d8a"
+    />
+    <g clipPath="url(#tkid2-shield)">
+      {/* Red half (per bend) with white bend */}
+      <path d="M 4 4 L 60 60 L 4 60 Z" fill="#a32c26" />
+      <path d="M 2 8 L 58 64 M 8 2 L 64 58" stroke="#f2e8cf" strokeWidth="6" />
+      {/* Crowns */}
+      {[
+        [22, 20],
+        [42, 28],
+        [26, 42],
+      ].map(([x, y]) => (
+        <g key={`${x}-${y}`} transform={`translate(${x}, ${y})`}>
+          <path
+            d="M -7 4 L -8 -5 L -3.5 -0.5 L 0 -7 L 3.5 -0.5 L 8 -5 L 7 4 Z"
+            fill="#e0b44a"
+            stroke="#8a6d24"
+            strokeWidth="1.2"
+            strokeLinejoin="round"
+          />
+          <rect x="-7" y="4" width="14" height="3" rx="1" fill="#c8a244" />
+        </g>
+      ))}
+    </g>
+    {/* Shield outline */}
+    <path
+      d="M 12 8 L 52 8 C 53.5 9.5 54 11 54 13 L 54 34 C 54 47 45 54 32 59 C 19 54 10 47 10 34 L 10 13 C 10 11 10.5 9.5 12 8 Z"
+      fill="none"
+      stroke="#3a2c1a"
       strokeWidth="2.5"
       strokeLinejoin="round"
     />
-    {/* Crown base band */}
-    <rect x="10" y="44" width="44" height="8" rx="2" fill="#5B2E93" />
-    {/* Jewels */}
-    <circle cx="22" cy="34" r="3" fill="#F4C947" />
-    <circle cx="32" cy="26" r="3.5" fill="#E84C4C" />
-    <circle cx="42" cy="34" r="3" fill="#4FB7BC" />
   </svg>
 );
 

--- a/src/features/tkid2/ai/botPolicy.test.ts
+++ b/src/features/tkid2/ai/botPolicy.test.ts
@@ -1,104 +1,68 @@
+import { chooseAction, evaluate } from "./botPolicy";
 import {
-  Difficulty,
-  chooseAction,
-  evaluate,
-} from "./botPolicy";
-import {
-  TKID2State,
+  Tkid2State,
   applyAction,
   currentPlayer,
-  currentRegionId,
+  gameResult,
   isGameOver,
   legalActions,
   newGame,
 } from "../engine/tkid2Engine";
 
-const P = [
-  { id: "p1", name: "Human", isBot: false },
-  { id: "p2", name: "Bot", isBot: true },
+const PLAYERS = [
+  { id: "bot-1", name: "One", isBot: true },
+  { id: "bot-2", name: "Two", isBot: true },
+  { id: "bot-3", name: "Three", isBot: true },
 ];
 
 describe("botPolicy", () => {
-  it("always returns a legal action for the player on turn", () => {
-    const s = newGame(P, 21);
-    // Move to the bot's turn.
-    const afterHuman = applyAction(s, { type: "pass" }).state;
-    const bot = currentPlayer(afterHuman);
-    const action = chooseAction(afterHuman, bot.id, "godlike");
-    const legal = legalActions(afterHuman);
-    expect(legal).toContainEqual(action);
+  it("always returns a legal action", () => {
+    const state = newGame(PLAYERS, 17);
+    const action = chooseAction(state, "bot-1", "godlike");
+    const res = applyAction(state, action);
+    expect(res.error).toBeUndefined();
   });
 
-  it("is deterministic for the same state and difficulty", () => {
-    const s = newGame(P, 33);
-    const a = chooseAction(s, "p1", "godlike");
-    const b = chooseAction(s, "p1", "godlike");
+  it("is deterministic", () => {
+    const state = newGame(PLAYERS, 31);
+    const a = chooseAction(state, "bot-1", "normal");
+    const b = chooseAction(state, "bot-1", "normal");
     expect(a).toEqual(b);
   });
 
-  it("prefers taking a follower of the leading faction on easy", () => {
-    let s = newGame(P, 5);
-    const region = currentRegionId(s)!;
-    s.regions[region] = { english: 3, scottish: 1, welsh: 0 };
-    const action = chooseAction(s, "p1", "easy");
-    expect(action).toEqual({ type: "pass", takeFollower: "english" });
-  });
-
-  it("evaluate rewards alignment with the projected deciding faction", () => {
-    const base = newGame(P, 5);
-    const region = currentRegionId(base)!;
-    // Make english clearly the projected winner of the contested region.
-    base.regions[region] = { english: 5, scottish: 0, welsh: 0 };
-    const withEnglish: TKID2State = {
-      ...base,
-      players: [
-        { ...base.players[0], court: { english: 3, scottish: 0, welsh: 0 } },
-        { ...base.players[1], court: { english: 0, scottish: 0, welsh: 0 } },
-      ],
-    };
-    const without: TKID2State = {
-      ...base,
-      players: [
-        { ...base.players[0], court: { english: 0, scottish: 0, welsh: 0 } },
-        { ...base.players[1], court: { english: 0, scottish: 0, welsh: 0 } },
-      ],
-    };
-    expect(evaluate(withEnglish, "p1")).toBeGreaterThan(evaluate(without, "p1"));
-  });
-
-  it.each<Difficulty>(["easy", "normal", "godlike"])(
-    "drives a full 2-player game to completion (%s)",
-    (difficulty) => {
-      let s = newGame(P, 77);
-      let guard = 0;
-      while (!isGameOver(s) && guard < 2000) {
-        guard++;
-        const player = currentPlayer(s);
-        const action = chooseAction(s, player.id, difficulty);
-        const res = applyAction(s, action);
+  it("plays a bots-only game to completion at every difficulty", () => {
+    for (const difficulty of ["easy", "normal", "godlike"] as const) {
+      let state: Tkid2State = newGame(PLAYERS, 5, {
+        advanced: difficulty === "godlike",
+      });
+      let steps = 0;
+      while (!isGameOver(state) && steps < 1000) {
+        const onTurn = currentPlayer(state).id;
+        const action = chooseAction(state, onTurn, difficulty);
+        const res = applyAction(state, action);
         expect(res.error).toBeUndefined();
-        s = res.state;
+        state = res.state;
+        steps++;
       }
-      expect(isGameOver(s)).toBe(true);
-    },
-  );
-
-  it("drives a human + 2 bot game with mixed difficulties", () => {
-    const three = [
-      { id: "p1", name: "Human", isBot: false },
-      { id: "p2", name: "Bot A", isBot: true },
-      { id: "p3", name: "Bot B", isBot: true },
-    ];
-    let s = newGame(three, 99);
-    let guard = 0;
-    while (!isGameOver(s) && guard < 3000) {
-      guard++;
-      const player = currentPlayer(s);
-      const diff: Difficulty = player.id === "p2" ? "godlike" : "normal";
-      const res = applyAction(s, chooseAction(s, player.id, diff));
-      expect(res.error).toBeUndefined();
-      s = res.state;
+      expect(isGameOver(state)).toBe(true);
+      expect(gameResult(state)).not.toBeNull();
     }
-    expect(isGameOver(s)).toBe(true);
+  });
+
+  it("evaluate prefers courts aligned with the strongest faction", () => {
+    const state = newGame(PLAYERS, 8);
+    // Give bot-1 a court stacked with the projected leader everywhere.
+    const richer = JSON.parse(JSON.stringify(state)) as Tkid2State;
+    richer.players[0].court = { scottish: 3, welsh: 3, english: 3 };
+    expect(evaluate(richer, "bot-1")).toBeGreaterThan(evaluate(state, "bot-1"));
+  });
+
+  it("summons when a summon is pending", () => {
+    let state = newGame(PLAYERS, 12);
+    const play = legalActions(state).find((a) => a.type === "play")!;
+    state = applyAction(state, play).state;
+    expect(state.pendingSummon).toBe(true);
+    const action = chooseAction(state, "bot-1", "normal");
+    expect(action.type).toBe("summon");
   });
 });

--- a/src/features/tkid2/ai/botPolicy.ts
+++ b/src/features/tkid2/ai/botPolicy.ts
@@ -1,176 +1,165 @@
 /**
- * TKID2 NPC policy.
+ * The King Is Dead — NPC policy.
  *
- * Pure function: given a state and the id of the bot whose turn it is, return a
- * single legal `TKID2Action`. Deterministic (no RNG) so behaviour is
- * reproducible in tests. Uses a one-ply search: enumerate every legal action,
- * apply it, and score the resulting state with a heuristic that estimates the
- * bot's final alignment advantage. Difficulty controls how greedily the bot
- * plays and how far it looks.
+ * Pure and deterministic: given a state and the id of the bot on turn, return
+ * one legal `Tkid2Action`. One-ply greedy search: apply every legal action and
+ * score the result with a heuristic estimating the bot's chance to be crowned.
+ *
+ * The heuristic thinks like the game does:
+ *  - project which faction will be the most powerful (regions controlled plus
+ *    the leader of the currently contested region),
+ *  - value court followers of factions weighted by how powerful those factions
+ *    are projected to be,
+ *  - value complete follower sets more as instability discs hit the board
+ *    (they win the game if the French invade),
+ *  - value holding cards a little (options are power).
  */
 import {
-  CrownOwner,
   FACTIONS,
   Faction,
-  INVASION_THRESHOLD,
   PlayerId,
-  TKID2Action,
-  TKID2State,
+  Tkid2Action,
+  Tkid2State,
   applyAction,
-  crownCounts,
+  contestedRegionId,
+  controlledCounts,
   currentPlayer,
-  currentRegionId,
+  gameResult,
+  instabilityOnBoard,
+  isGameOver,
   legalActions,
-  projectedOwner,
+  majorityFaction,
+  setCount,
 } from "../engine/tkid2Engine";
 
 export type Difficulty = "easy" | "normal" | "godlike";
 
-/**
- * Estimate which faction's alignment will decide the game, using resolved
- * crowns plus the projected owner of the region currently being contested.
- * This is a cheap forecast — future regions are ignored.
- */
-function projectedCrownCounts(state: TKID2State): Record<CrownOwner, number> {
-  const counts = { ...crownCounts(state) };
-  const region = currentRegionId(state);
-  if (region !== null) {
-    const owner = projectedOwner(state.regions[region]);
-    counts[owner] += 1;
+/** Projected power score per faction: regions held + leads in the contested
+ *  region count as a probable extra region. */
+function projectedRegions(state: Tkid2State): Record<Faction, number> {
+  const counts = { ...controlledCounts(state) };
+  const contested = contestedRegionId(state);
+  if (contested) {
+    const leader = majorityFaction(state.regions[contested].cubes);
+    if (leader) counts[leader] += 1;
   }
   return counts;
 }
 
-function projectedDecidingFaction(state: TKID2State): {
-  faction: Faction;
-  invasion: boolean;
-} {
-  const counts = projectedCrownCounts(state);
-  const invasion = counts.french >= INVASION_THRESHOLD;
-  const ranked = FACTIONS.map((f) => ({ faction: f, crowns: counts[f] })).sort(
-    (a, b) =>
-      b.crowns - a.crowns ||
-      FACTIONS.indexOf(a.faction) - FACTIONS.indexOf(b.faction),
-  );
-  return {
-    faction: invasion ? ranked[ranked.length - 1].faction : ranked[0].faction,
-    invasion,
-  };
+function rankedFactions(state: Tkid2State): Faction[] {
+  const proj = projectedRegions(state);
+  return [...FACTIONS].sort((a, b) => proj[b] - proj[a]);
 }
 
-/**
- * Heuristic value of `state` from `botId`'s perspective. Higher is better.
- * Combines:
- *  - alignment advantage in the projected deciding faction (dominant term),
- *  - a small bonus for total followers held (flexibility),
- *  - a small nudge to avoid runaway foreign invasion unless we're set up for it.
- */
-export function evaluate(state: TKID2State, botId: PlayerId): number {
-  const { faction: deciding, invasion } = projectedDecidingFaction(state);
+export function evaluate(state: Tkid2State, botId: PlayerId): number {
   const me = state.players.find((p) => p.id === botId);
   if (!me) return 0;
-  const opponents = state.players.filter((p) => p.id !== botId);
 
-  const myAlign = me.court[deciding];
-  const bestOpp = opponents.reduce(
-    (m, p) => Math.max(m, p.court[deciding]),
-    0,
-  );
-  let value = (myAlign - bestOpp) * 10;
-
-  // Small preference for a larger, more flexible court.
-  const myTotal = FACTIONS.reduce((a, f) => a + me.court[f], 0);
-  value += myTotal * 0.5;
-
-  // If we're not aligned to profit from an invasion, discourage it slightly.
-  const counts = projectedCrownCounts(state);
-  if (!invasion && counts.french > 0) {
-    value -= counts.french * 0.25;
+  if (isGameOver(state)) {
+    const result = gameResult(state);
+    return result && result.winnerIds.includes(botId) ? 1000 : -1000;
   }
+
+  const opponents = state.players.filter((p) => p.id !== botId);
+  const ranked = rankedFactions(state);
+  const proj = projectedRegions(state);
+
+  let value = 0;
+  // Court alignment: margin over the best opponent, weighted by the faction's
+  // projected power (most powerful faction dominates the coronation).
+  ranked.forEach((f, i) => {
+    const weight = [10, 4, 1][i] * (1 + proj[f] / 4);
+    const bestOpp = opponents.reduce((m, p) => Math.max(m, p.court[f]), 0);
+    value += weight * (me.court[f] - bestOpp);
+  });
+
+  // Invasion insurance: sets matter more with each instability disc placed.
+  const discs = instabilityOnBoard(state);
+  const setWeight = [0.5, 4, 14][Math.min(discs, 2)];
+  const bestOppSets = opponents.reduce((m, p) => Math.max(m, setCount(p.court)), 0);
+  value += setWeight * (setCount(me.court) - bestOppSets);
+
+  // A slightly larger court and cards in hand are both flexibility.
+  value += 0.3 * (me.court.scottish + me.court.welsh + me.court.english);
+  value += 0.4 * me.hand.length;
 
   return value;
 }
 
-/**
- * Deterministic tiebreak key so equal-value actions resolve consistently.
- * Prefers card plays over passing early game, and cheaper option ordering.
- */
-function actionKey(a: TKID2Action): string {
-  if (a.type === "pass") return `z-pass-${a.takeFollower ?? ""}`;
-  return `a-${a.cardId}-${a.fromRegion ?? ""}-${a.faction ?? ""}`;
+/** Stable ordering so equal-value actions resolve deterministically. */
+function actionKey(a: Tkid2Action): string {
+  if (a.type === "pass") return "z";
+  if (a.type === "summon") return `s-${a.regionId}-${a.faction}`;
+  return `p-${a.cardId}-${JSON.stringify(a.params)}`;
 }
 
-/**
- * Choose the bot's action. One-ply greedy over the heuristic. Difficulty:
- *  - godlike: full evaluation, always the best action.
- *  - normal:  best action, but ignores the invasion-avoidance nudge.
- *  - easy:    prefers simply taking a follower of the projected-winning faction
- *             (short-sighted), only playing cards when passing is unavailable.
- */
+const MAX_CANDIDATES = 400;
+
+/** Deterministically thin very large action lists to keep the bot snappy. */
+function thin(actions: Tkid2Action[]): Tkid2Action[] {
+  if (actions.length <= MAX_CANDIDATES) return actions;
+  const step = actions.length / MAX_CANDIDATES;
+  const out: Tkid2Action[] = [];
+  for (let i = 0; i < MAX_CANDIDATES; i++) {
+    out.push(actions[Math.floor(i * step)]);
+  }
+  return out;
+}
+
 export function chooseAction(
-  state: TKID2State,
+  state: Tkid2State,
   botId: PlayerId,
   difficulty: Difficulty = "normal",
-): TKID2Action {
-  const actions = legalActions(state);
-  if (actions.length === 0) {
-    return { type: "pass" };
-  }
+): Tkid2Action {
+  const all = legalActions(state);
+  if (all.length === 0) return { type: "pass" };
+  if (currentPlayer(state).id !== botId) return all[0];
 
-  // Sanity: only decide for the player actually on turn.
-  const onTurn = currentPlayer(state);
-  if (onTurn.id !== botId) {
-    // Defensive fallback — should not happen in normal drive flow.
-    return actions[0];
-  }
+  if (difficulty === "easy") return easyAction(state, all);
 
-  if (difficulty === "easy") {
-    return easyAction(state, actions);
-  }
-
-  let best: TKID2Action | null = null;
+  const actions = thin(all);
+  let best: Tkid2Action | null = null;
   let bestScore = -Infinity;
   for (const action of actions) {
     const res = applyAction(state, action);
     if (res.error) continue;
     let score = evaluate(res.state, botId);
-    if (difficulty === "normal") {
-      // Normal bots are a touch less strategic: dampen the alignment term.
-      score = score * 0.9;
+    if (difficulty === "normal" && action.type === "play") {
+      // Normal bots slightly undervalue spending cards, making them play
+      // earlier (and more fallibly) than a godlike bot would.
+      score += 0.6;
     }
     if (
       score > bestScore ||
-      (score === bestScore &&
-        best !== null &&
-        actionKey(action) < actionKey(best))
+      (score === bestScore && best !== null && actionKey(action) < actionKey(best))
     ) {
       bestScore = score;
       best = action;
     }
   }
-  return best ?? actions[0];
+  return best ?? all[0];
 }
 
 /**
- * Easy bots: greedily grab a follower of the faction currently leading the
- * contested region; otherwise take any follower; otherwise play the first
- * available card.
+ * Easy bots: when summoning, grab a follower of the projected strongest
+ * faction; otherwise mostly pass, occasionally (deterministically) playing
+ * whatever card comes first.
  */
-function easyAction(state: TKID2State, actions: TKID2Action[]): TKID2Action {
-  const region = currentRegionId(state);
-  if (region !== null) {
-    const owner = projectedOwner(state.regions[region]);
-    if (owner !== "french") {
-      const grab = actions.find(
-        (a) => a.type === "pass" && a.takeFollower === owner,
-      );
-      if (grab) return grab;
+function easyAction(state: Tkid2State, actions: Tkid2Action[]): Tkid2Action {
+  const ranked = rankedFactions(state);
+  const summons = actions.filter((a) => a.type === "summon");
+  if (summons.length > 0) {
+    for (const f of ranked) {
+      const found = summons.find((a) => a.type === "summon" && a.faction === f);
+      if (found) return found;
     }
+    return summons[0];
   }
-  const anyGrab = actions.find(
-    (a) => a.type === "pass" && a.takeFollower !== undefined,
-  );
-  if (anyGrab) return anyGrab;
-  const card = actions.find((a) => a.type === "playCard");
-  return card ?? actions[0];
+  // Play a card roughly every other opportunity, keyed off the action count.
+  const wantsToPlay = state.actionSeq % 2 === 0;
+  if (wantsToPlay) {
+    const play = actions.find((a) => a.type === "play");
+    if (play) return play;
+  }
+  return actions.find((a) => a.type === "pass") ?? actions[0];
 }

--- a/src/features/tkid2/engine/tkid2Engine.test.ts
+++ b/src/features/tkid2/engine/tkid2Engine.test.ts
@@ -1,305 +1,424 @@
 import {
+  BASE_HAND,
   FACTIONS,
-  INVASION_THRESHOLD,
-  REGIONS,
-  TKID2State,
+  FOLLOWERS_PER_FACTION,
+  FOLLOWERS_PER_FACTION_2P,
+  Faction,
+  HOME_REGION,
+  REGION_IDS,
+  SETUP_FOLLOWERS_PER_REGION,
+  Tkid2State,
   applyAction,
-  crownCounts,
-  currentPlayer,
-  currentRegionId,
-  decidingFaction,
+  contestedRegionId,
+  controlledCounts,
+  enumerateCardParams,
+  factionStandings,
+  gameResult,
+  instabilityOnBoard,
   isGameOver,
-  isInvasion,
   legalActions,
+  majorityFaction,
   newGame,
-  projectedOwner,
-  regionLeaders,
-  results,
-  seededShuffle,
-  startingHand,
-  winners,
+  setCount,
+  summonOptions,
+  supportTargets,
+  totalCubes,
 } from "./tkid2Engine";
 
-const P = [
-  { id: "p1", name: "Alice", isBot: false },
-  { id: "p2", name: "Bob", isBot: true },
+const P3 = [
+  { id: "a", name: "Alice", isBot: false },
+  { id: "b", name: "Bob", isBot: true },
+  { id: "c", name: "Cara", isBot: true },
 ];
 
-describe("tkid2 setup", () => {
-  it("gives every player the identical 8-card hand", () => {
-    const s = newGame(P, 42);
-    expect(startingHand()).toHaveLength(8);
-    for (const p of s.players) {
+function conservation(state: Tkid2State, perFaction: number) {
+  for (const f of FACTIONS) {
+    let sum = state.supply[f];
+    for (const id of REGION_IDS) sum += state.regions[id].cubes[f];
+    for (const p of state.players) sum += p.court[f];
+    expect(sum).toBe(perFaction);
+  }
+}
+
+/** Force-clear a region and give control to a faction (test helper). */
+function grantControl(state: Tkid2State, regionId: string, faction: Faction) {
+  const region = state.regions[regionId as keyof typeof state.regions];
+  for (const f of FACTIONS) {
+    state.supply[f] += region.cubes[f];
+    region.cubes[f] = 0;
+  }
+  region.control = faction;
+  const slot = state.slots.find((s) => s.regionId === regionId)!;
+  slot.faceUp = false;
+}
+
+describe("setup", () => {
+  it("deals four followers to every region, two per court, rest to supply", () => {
+    const state = newGame(P3, 42);
+    for (const id of REGION_IDS) {
+      expect(totalCubes(state.regions[id].cubes)).toBe(SETUP_FOLLOWERS_PER_REGION);
+    }
+    for (const f of FACTIONS) {
+      expect(state.regions[HOME_REGION[f]].cubes[f]).toBeGreaterThanOrEqual(2);
+    }
+    for (const p of state.players) {
+      expect(totalCubes(p.court)).toBe(2);
+      expect(p.hand).toEqual(BASE_HAND);
+    }
+    conservation(state, FOLLOWERS_PER_FACTION);
+    expect(state.slots).toHaveLength(8);
+    expect(state.slots.every((s) => s.faceUp)).toBe(true);
+    expect(new Set(state.slots.map((s) => s.regionId)).size).toBe(8);
+    expect(state.instabilityInFrance).toBe(3);
+  });
+
+  it("removes two followers of each faction in a two-player game", () => {
+    const state = newGame(P3.slice(0, 2), 7);
+    conservation(state, FOLLOWERS_PER_FACTION_2P);
+  });
+
+  it("advanced game: no support cards, three unique cunning cards each", () => {
+    const state = newGame(P3, 3, { advanced: true });
+    const seen = new Set<string>();
+    for (const p of state.players) {
       expect(p.hand).toHaveLength(8);
-      expect(p.court).toEqual({ english: 0, scottish: 0, welsh: 0 });
-      expect(p.passed).toBe(false);
+      const cunning = p.hand.filter(
+        (c) =>
+          !["assemble-1", "assemble-2", "negotiate", "manoeuvre", "outmanoeuvre"].includes(c),
+      );
+      expect(cunning).toHaveLength(3);
+      expect(p.hand).not.toContain("scottish-support");
+      cunning.forEach((c) => {
+        expect(seen.has(c)).toBe(false);
+        seen.add(c);
+      });
     }
   });
 
-  it("seeds all regions and is deterministic for a given seed", () => {
-    const a = newGame(P, 7);
-    const b = newGame(P, 7);
-    const c = newGame(P, 8);
-    expect(a.eventOrder).toEqual(b.eventOrder);
-    expect(a.eventOrder).not.toEqual(c.eventOrder); // extremely likely differs
-    expect(a.eventOrder.slice().sort()).toEqual(REGIONS.map((r) => r.id).sort());
-    for (const r of REGIONS) {
-      expect(a.regions[r.id]).toEqual(r.setup);
-    }
-  });
-
-  it("rejects illegal player counts", () => {
-    expect(() => newGame([P[0]], 1)).toThrow();
-    expect(() =>
-      newGame(
-        Array.from({ length: 5 }, (_, i) => ({ id: `x${i}`, name: `x${i}`, isBot: false })),
-        1,
-      ),
-    ).toThrow();
-  });
-
-  it("seededShuffle is a permutation", () => {
-    const input = [1, 2, 3, 4, 5];
-    const out = seededShuffle(input, 123);
-    expect(out.slice().sort()).toEqual(input);
+  it("is deterministic for a given seed", () => {
+    expect(newGame(P3, 99)).toEqual(newGame(P3, 99));
   });
 });
 
-describe("region resolution", () => {
-  it("regionLeaders / projectedOwner detect majority and ties", () => {
-    expect(regionLeaders({ english: 3, scottish: 1, welsh: 0 })).toEqual(["english"]);
-    expect(projectedOwner({ english: 3, scottish: 1, welsh: 0 })).toBe("english");
-    expect(projectedOwner({ english: 2, scottish: 2, welsh: 0 })).toBe("french");
-    expect(projectedOwner({ english: 0, scottish: 0, welsh: 0 })).toBe("french");
-  });
-
-  it("resolves a region and advances when everyone passes", () => {
-    let s = newGame(P, 3);
-    const region = currentRegionId(s)!;
-    const owner = projectedOwner(s.regions[region]);
-
-    // Both players pass without taking followers -> region resolves as-is.
-    let r = applyAction(s, { type: "pass" });
-    s = r.state;
-    r = applyAction(s, { type: "pass" });
-    s = r.state;
-
-    expect(r.events.some((e) => e.kind === "regionResolved")).toBe(true);
-    expect(s.crowns[region]).toBe(owner);
-    // Settled region cubes cleared.
-    expect(s.regions[region]).toEqual({ english: 0, scottish: 0, welsh: 0 });
-    expect(s.eventIndex).toBe(1);
-    // Pass flags reset for the next round.
-    expect(s.players.every((p) => !p.passed)).toBe(true);
-  });
-});
-
-describe("actions", () => {
-  it("muster adds cubes and consumes the card", () => {
-    let s = newGame(P, 5);
-    const region = currentRegionId(s)!;
-    const before = s.regions[region].english;
-    const r = applyAction(s, { type: "playCard", cardId: "muster-english" });
-    expect(r.error).toBeUndefined();
-    s = r.state;
-    expect(s.regions[region].english).toBe(before + 2);
-    expect(s.players[0].hand).not.toContain("muster-english");
-    // Turn passed to the other player.
-    expect(s.currentPlayerIndex).toBe(1);
-  });
-
-  it("exile removes cubes (floored at 0) and needs a target", () => {
-    let s = newGame(P, 5);
-    // Point the contested region at one we control the contents of.
-    const region = currentRegionId(s)!;
-    s.regions[region] = { english: 1, scottish: 0, welsh: 0 };
-    // Exiling scottish (none present) is rejected.
-    const bad = applyAction(s, { type: "playCard", cardId: "exile-scottish" });
-    expect(bad.error).toBeDefined();
-    // Exiling english removes up to 2, floored at 0.
-    const r = applyAction(s, { type: "playCard", cardId: "exile-english" });
-    expect(r.state.regions[region].english).toBe(0);
-  });
-
-  it("manoeuvre pulls cubes from an adjacent region only", () => {
-    let s = newGame(P, 5);
-    const region = currentRegionId(s)!;
-    const def = REGIONS.find((r) => r.id === region)!;
-    const adj = def.adjacent[0];
-    // Ensure the neighbour has welsh cubes to move.
-    s.regions[adj] = { english: 0, scottish: 0, welsh: 2 };
-    const before = s.regions[region].welsh;
-    const r = applyAction(s, {
-      type: "playCard",
-      cardId: "manoeuvre-1",
-      fromRegion: adj,
-      faction: "welsh",
-    });
-    expect(r.error).toBeUndefined();
-    expect(r.state.regions[region].welsh).toBe(before + 2);
-    expect(r.state.regions[adj].welsh).toBe(0);
-
-    // Non-adjacent source is rejected.
-    const nonAdj = REGIONS.map((x) => x.id).find(
-      (id) => id !== region && !def.adjacent.includes(id),
-    )!;
-    const bad = applyAction(s, {
-      type: "playCard",
-      cardId: "manoeuvre-1",
-      fromRegion: nonAdj,
-      faction: "welsh",
-    });
-    expect(bad.error).toBeDefined();
-  });
-
-  it("pass can take a follower present in the region", () => {
-    let s = newGame(P, 5);
-    const region = currentRegionId(s)!;
-    s.regions[region] = { english: 2, scottish: 0, welsh: 0 };
-    const r = applyAction(s, { type: "pass", takeFollower: "english" });
-    expect(r.error).toBeUndefined();
-    expect(r.state.players[0].court.english).toBe(1);
-    expect(r.state.regions[region].english).toBe(1);
-    expect(r.state.players[0].passed).toBe(true);
-  });
-
-  it("rejects taking a follower colour not present", () => {
-    let s = newGame(P, 5);
-    const region = currentRegionId(s)!;
-    s.regions[region] = { english: 0, scottish: 0, welsh: 0 };
-    const r = applyAction(s, { type: "pass", takeFollower: "english" });
-    expect(r.error).toBeDefined();
-  });
-
-  it("rejects a card that is not in hand", () => {
-    let s = newGame(P, 5);
-    s = applyAction(s, { type: "playCard", cardId: "muster-english" }).state; // p0 plays, p1 to move
-    s = applyAction(s, { type: "pass" }).state; // p1 passes -> back to p0
-    // p0 already used muster-english.
-    const r = applyAction(s, { type: "playCard", cardId: "muster-english" });
-    expect(r.error).toBeDefined();
-  });
-});
-
-describe("legalActions", () => {
-  it("always offers pass options and card plays", () => {
-    const s = newGame(P, 5);
-    const actions = legalActions(s);
-    expect(actions.some((a) => a.type === "pass")).toBe(true);
-    expect(actions.some((a) => a.type === "playCard")).toBe(true);
-    // Passed players have no actions.
-    const passedState: TKID2State = {
-      ...s,
-      players: s.players.map((p) => ({ ...p, passed: true })),
-    };
-    expect(legalActions(passedState)).toEqual([]);
-  });
-
-  it("only lists exiles for factions present", () => {
-    const s = newGame(P, 5);
-    const region = currentRegionId(s)!;
-    s.regions[region] = { english: 1, scottish: 0, welsh: 0 };
-    const actions = legalActions(s);
-    const exiles = actions.filter(
-      (a) => a.type === "playCard" && a.cardId.startsWith("exile-"),
+describe("support cards", () => {
+  it("targets only regions bordering the open home region at the start", () => {
+    const state = newGame(P3, 1);
+    // Nothing is controlled yet, so Scottish Support may only reach
+    // regions bordering Moray — which is Strathclyde alone.
+    expect(supportTargets(state, "scottish").sort()).toEqual(["strathclyde"]);
+    expect(supportTargets(state, "welsh").sort()).toEqual(
+      ["devon", "lancaster", "warwick"].sort(),
     );
-    expect(exiles).toEqual([{ type: "playCard", cardId: "exile-english" }]);
+    expect(supportTargets(state, "english").sort()).toEqual(
+      ["devon", "northumbria", "warwick"].sort(),
+    );
+  });
+
+  it("places two followers from the supply and then requires a summon", () => {
+    const state = newGame(P3, 1);
+    state.supply.scottish = 5;
+    const before = state.regions.strathclyde.cubes.scottish;
+    const params = enumerateCardParams(state, "scottish-support")[0];
+    const res = applyAction(state, { type: "play", cardId: "scottish-support", params });
+    expect(res.error).toBeUndefined();
+    expect(res.state.regions.strathclyde.cubes.scottish).toBe(before + 2);
+    expect(res.state.supply.scottish).toBe(3);
+    expect(res.state.pendingSummon).toBe(true);
+    // Only summon actions are legal now.
+    const acts = legalActions(res.state);
+    expect(acts.length).toBeGreaterThan(0);
+    expect(acts.every((a) => a.type === "summon")).toBe(true);
+    const after = applyAction(res.state, acts[0]);
+    expect(after.error).toBeUndefined();
+    expect(totalCubes(after.state.players[0].court)).toBe(3);
+    expect(after.state.currentPlayerIndex).toBe(1);
+    expect(after.state.players[0].hand).not.toContain("scottish-support");
+    expect(after.state.players[0].discard).toEqual(["scottish-support"]);
+  });
+
+  it("targets regions bordering controlled regions once the home is closed", () => {
+    const state = newGame(P3, 1);
+    grantControl(state, "moray", "scottish");
+    // Moray is controlled → home fallback gone; Strathclyde borders Moray.
+    expect(supportTargets(state, "scottish").sort()).toEqual(["strathclyde"]);
+    grantControl(state, "warwick", "scottish");
+    expect(supportTargets(state, "scottish").sort()).toEqual(
+      ["devon", "essex", "gwynedd", "lancaster", "northumbria", "strathclyde"].sort(),
+    );
+  });
+
+  it("places as many as possible when the supply runs short", () => {
+    const state = newGame(P3, 1);
+    state.supply.scottish = 1;
+    const params = enumerateCardParams(state, "scottish-support");
+    expect(params.length).toBeGreaterThan(0);
+    expect(params.every((p) => (p.placements ?? []).length === 1)).toBe(true);
+  });
+
+  it("can only be played for no effect when the supply is empty", () => {
+    const state = newGame(P3, 1);
+    state.supply.scottish = 0;
+    expect(enumerateCardParams(state, "scottish-support")).toHaveLength(0);
+    const res = applyAction(state, {
+      type: "play",
+      cardId: "scottish-support",
+      params: {},
+    });
+    expect(res.error).toBeUndefined();
   });
 });
 
-describe("full game & scoring", () => {
-  it("plays out every region and ends the game", () => {
-    let s = newGame(P, 11);
-    let guard = 0;
-    while (!isGameOver(s) && guard < 1000) {
-      guard++;
+describe("assemble", () => {
+  it("places one follower of each available faction anywhere", () => {
+    const state = newGame(P3, 5);
+    state.supply = { scottish: 3, welsh: 3, english: 0 };
+    const params = enumerateCardParams(state, "assemble-1")[0];
+    expect(params.placements).toHaveLength(2); // english skipped: no supply
+    const res = applyAction(state, { type: "play", cardId: "assemble-1", params });
+    expect(res.error).toBeUndefined();
+    expect(res.state.supply.scottish + res.state.supply.welsh).toBe(4);
+  });
+});
+
+describe("negotiate", () => {
+  it("swaps two face-up region cards and leaves a negotiation disc", () => {
+    const state = newGame(P3, 8);
+    const [s1, s2] = [state.slots[0], state.slots[1]];
+    const res = applyAction(state, {
+      type: "play",
+      cardId: "negotiate",
+      params: { slotA: s1.position, slotB: s2.position, discRegionId: s1.regionId },
+    });
+    expect(res.error).toBeUndefined();
+    const n1 = res.state.slots[0];
+    const n2 = res.state.slots[1];
+    expect(n1.regionId).toBe(s2.regionId);
+    expect(n2.regionId).toBe(s1.regionId);
+    // The disc followed the chosen card to its new space.
+    expect(n2.negotiationDisc).toBe(true);
+    expect(n1.negotiationDisc).toBe(false);
+    // A card with a disc can no longer be swapped.
+    expect(
+      enumerateCardParams(res.state, "negotiate").some(
+        (p) => p.slotA === n2.position || p.slotB === n2.position,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("manoeuvre and outmanoeuvre", () => {
+  it("swaps one follower for one follower between two regions", () => {
+    const state = newGame(P3, 11);
+    const params = enumerateCardParams(state, "manoeuvre")[0]!;
+    const { from, to } = params;
+    const beforeFrom = state.regions[from!.regionId].cubes[from!.factions[0]];
+    const beforeTo = state.regions[to!.regionId].cubes[to!.factions[0]];
+    const res = applyAction(state, { type: "play", cardId: "manoeuvre", params });
+    expect(res.error).toBeUndefined();
+    if (from!.factions[0] !== to!.factions[0]) {
+      expect(res.state.regions[from!.regionId].cubes[from!.factions[0]]).toBe(beforeFrom - 1);
+      expect(res.state.regions[to!.regionId].cubes[to!.factions[0]]).toBe(beforeTo - 1);
+    }
+    conservation(res.state, FOLLOWERS_PER_FACTION);
+  });
+
+  it("forbids immediately undoing another player's manoeuvre", () => {
+    const state = newGame(P3, 11);
+    // Alice manoeuvres.
+    const params = enumerateCardParams(state, "manoeuvre").find(
+      (p) => p.from!.factions[0] !== p.to!.factions[0],
+    )!;
+    let s = applyAction(state, { type: "play", cardId: "manoeuvre", params }).state;
+    s = applyAction(s, legalActions(s)[0]).state; // Alice summons
+    // Bob tries to reverse it: the exact undo must not be enumerated.
+    const reverse = {
+      from: { regionId: params.from!.regionId, factions: params.to!.factions },
+      to: { regionId: params.to!.regionId, factions: params.from!.factions },
+    };
+    const rejected = applyAction(s, {
+      type: "play",
+      cardId: "manoeuvre",
+      params: reverse,
+    });
+    expect(rejected.error).toBeDefined();
+  });
+
+  it("outmanoeuvre swaps one follower for two in a bordering region", () => {
+    const state = newGame(P3, 13);
+    const params = enumerateCardParams(state, "outmanoeuvre")[0]!;
+    expect(params.to!.factions).toHaveLength(2);
+    const res = applyAction(state, { type: "play", cardId: "outmanoeuvre", params });
+    expect(res.error).toBeUndefined();
+    const a = res.state.regions[params.from!.regionId];
+    const b = res.state.regions[params.to!.regionId];
+    expect(totalCubes(a.cubes)).toBe(SETUP_FOLLOWERS_PER_REGION + 1);
+    expect(totalCubes(b.cubes)).toBe(SETUP_FOLLOWERS_PER_REGION - 1);
+    conservation(res.state, FOLLOWERS_PER_FACTION);
+  });
+
+  it("rejects a partial outmanoeuvre while a full swap is available", () => {
+    const state = newGame(P3, 13);
+    const full = enumerateCardParams(state, "outmanoeuvre")[0]!;
+    const partial = {
+      from: full.from,
+      to: { regionId: full.to!.regionId, factions: [full.to!.factions[0]] },
+    };
+    const res = applyAction(state, {
+      type: "play",
+      cardId: "outmanoeuvre",
+      params: partial,
+    });
+    expect(res.error).toBeDefined();
+  });
+});
+
+describe("power struggles", () => {
+  function passRound(state: Tkid2State): Tkid2State {
+    let s = state;
+    for (let i = 0; i < state.players.length; i++) {
       s = applyAction(s, { type: "pass" }).state;
     }
-    expect(isGameOver(s)).toBe(true);
-    expect(Object.keys(s.crowns)).toHaveLength(REGIONS.length);
-    // crownCounts total equals number of regions.
-    const counts = crownCounts(s);
-    const total = FACTIONS.reduce((a, f) => a + counts[f], 0) + counts.french;
-    expect(total).toBe(REGIONS.length);
+    return s;
+  }
+
+  it("resolves the contested region for the majority faction", () => {
+    const state = newGame(P3, 21);
+    const contested = contestedRegionId(state)!;
+    state.regions[contested].cubes = { scottish: 3, welsh: 1, english: 0 };
+    const supplyBefore = state.supply.scottish;
+    const s = passRound(state);
+    expect(s.regions[contested].control).toBe("scottish");
+    expect(totalCubes(s.regions[contested].cubes)).toBe(0);
+    expect(s.supply.scottish).toBe(supplyBefore + 3);
+    expect(s.slots.find((sl) => sl.regionId === contested)!.faceUp).toBe(false);
+    expect(s.struggles).toHaveLength(1);
+    // The next lowest face-up card is now contested.
+    expect(contestedRegionId(s)).toBe(s.slots.find((sl) => sl.faceUp)!.regionId);
   });
 
-  it("normal game: strongest faction decides; most followers wins", () => {
-    // Hand-craft an ended state.
-    const s = newGame(P, 1);
-    const ended: TKID2State = {
-      ...s,
-      phase: "ended",
-      eventIndex: REGIONS.length,
-      crowns: {
-        r1: "english",
-        r2: "english",
-        r3: "english",
-        r4: "scottish",
-        r5: "welsh",
-        r6: "welsh",
-        r7: "scottish",
-        r8: "french",
-      } as any,
-      players: [
-        { ...s.players[0], court: { english: 3, scottish: 1, welsh: 0 } },
-        { ...s.players[1], court: { english: 2, scottish: 5, welsh: 0 } },
-      ],
-    };
-    expect(isInvasion(ended)).toBe(false);
-    expect(decidingFaction(ended)).toBe("english"); // 3 crowns
-    const ranked = results(ended);
-    expect(ranked[0].playerId).toBe("p1"); // more english followers
-    expect(winners(ended).map((w) => w.playerId)).toEqual(["p1"]);
+  it("marks a tied region unstable and moves a disc out of France", () => {
+    const state = newGame(P3, 22);
+    const contested = contestedRegionId(state)!;
+    state.regions[contested].cubes = { scottish: 2, welsh: 2, english: 0 };
+    const s = passRound(state);
+    expect(s.regions[contested].unstable).toBe(true);
+    expect(s.regions[contested].control).toBeNull();
+    expect(s.instabilityInFrance).toBe(2);
+    expect(instabilityOnBoard(s)).toBe(1);
   });
 
-  it("invasion flips to the weakest faction", () => {
-    const s = newGame(P, 1);
-    const crowns: Record<string, string> = {
-      r1: "french",
-      r2: "french",
-      r3: "french",
-      r4: "french", // >= INVASION_THRESHOLD
-      r5: "english",
-      r6: "english",
-      r7: "scottish",
-      r8: "welsh",
-    };
-    const ended: TKID2State = {
-      ...s,
-      phase: "ended",
-      eventIndex: REGIONS.length,
-      crowns: crowns as any,
-      players: [
-        { ...s.players[0], court: { english: 5, scottish: 0, welsh: 3 } },
-        { ...s.players[1], court: { english: 0, scottish: 0, welsh: 4 } },
-      ],
-    };
-    expect(INVASION_THRESHOLD).toBeLessThanOrEqual(4);
-    expect(isInvasion(ended)).toBe(true);
-    // Weakest native faction is welsh (1 crown) — ties broken by fixed order,
-    // scottish also has 1; welsh comes last so it is the weakest.
-    expect(decidingFaction(ended)).toBe("welsh");
-    const ranked = results(ended);
-    expect(ranked[0].playerId).toBe("p2"); // 4 welsh > 3 welsh
-  });
-
-  it("supports three players (human + 2 bots)", () => {
-    const three = [
-      { id: "p1", name: "Human", isBot: false },
-      { id: "p2", name: "Bot A", isBot: true },
-      { id: "p3", name: "Bot B", isBot: true },
-    ];
-    let s = newGame(three, 9);
-    expect(s.players).toHaveLength(3);
-    let guard = 0;
-    while (!isGameOver(s) && guard < 1000) {
-      guard++;
-      const player = currentPlayer(s);
-      // Alternate a card play and passes to exercise turn rotation.
-      const acts = legalActions(s);
-      s = applyAction(s, acts[0]).state;
-      expect(player).toBeDefined();
+  it("ends the game with an invasion on the third instability disc", () => {
+    let state = newGame(P3, 23);
+    for (let round = 0; round < 3; round++) {
+      const contested = contestedRegionId(state)!;
+      state.regions[contested].cubes = { scottish: 1, welsh: 1, english: 0 };
+      state = passRound(state);
     }
-    expect(isGameOver(s)).toBe(true);
+    expect(isGameOver(state)).toBe(true);
+    expect(state.ending).toBe("invasion");
+    const result = gameResult(state)!;
+    expect(result.ending).toBe("invasion");
+    expect(result.winnerIds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ends with a coronation when all eight struggles resolve", () => {
+    let state = newGame(P3, 24);
+    let round = 0;
+    while (!isGameOver(state) && round < 8) {
+      const contested = contestedRegionId(state)!;
+      state.regions[contested].cubes = { scottish: 2, welsh: 1, english: 0 };
+      state = passRound(state);
+      round++;
+    }
+    expect(isGameOver(state)).toBe(true);
+    expect(state.ending).toBe("coronation");
+    expect(controlledCounts(state).scottish).toBe(8);
+    const standings = factionStandings(state);
+    expect(standings[0].faction).toBe("scottish");
+    const result = gameResult(state)!;
+    const best = Math.max(...state.players.map((p) => p.court.scottish));
+    for (const row of result.results) {
+      if (row.winner) expect(row.score).toBe(best);
+    }
+  });
+
+  it("breaks faction power ties by the most recent struggle win", () => {
+    let state = newGame(P3, 25);
+    const order: Faction[] = [
+      "scottish",
+      "welsh",
+      "scottish",
+      "welsh",
+      "english",
+      "english",
+      "scottish",
+      "welsh", // welsh wins last
+    ];
+    let i = 0;
+    while (!isGameOver(state) && i < 8) {
+      const contested = contestedRegionId(state)!;
+      const cubes = { scottish: 0, welsh: 0, english: 0 };
+      cubes[order[i]] = 2;
+      state.regions[contested].cubes = cubes;
+      state = passRound(state);
+      i++;
+    }
+    // Scottish and Welsh both control 3 regions; Welsh won the final struggle.
+    const standings = factionStandings(state);
+    expect(standings[0].faction).toBe("welsh");
+    expect(standings[1].faction).toBe("scottish");
+  });
+});
+
+describe("scoring", () => {
+  it("counts complete follower sets for an invasion", () => {
+    expect(setCount({ scottish: 2, welsh: 1, english: 3 })).toBe(1);
+    expect(setCount({ scottish: 0, welsh: 4, english: 3 })).toBe(0);
+  });
+
+  it("majorityFaction requires a strict majority", () => {
+    expect(majorityFaction({ scottish: 2, welsh: 1, english: 0 })).toBe("scottish");
+    expect(majorityFaction({ scottish: 2, welsh: 2, english: 0 })).toBeNull();
+    expect(majorityFaction({ scottish: 0, welsh: 0, english: 0 })).toBeNull();
+  });
+});
+
+describe("full random games", () => {
+  function randomOf<T>(arr: T[], rng: () => number): T {
+    return arr[Math.floor(rng() * arr.length)];
+  }
+
+  it("always terminate and conserve followers", () => {
+    for (const seed of [1, 2, 3, 4, 5]) {
+      let rngState = seed * 7919 + 1;
+      const rng = () => {
+        rngState = (rngState * 1103515245 + 12345) & 0x7fffffff;
+        return rngState / 0x80000000;
+      };
+      let state = newGame(P3, seed, { advanced: seed % 2 === 0 });
+      let steps = 0;
+      while (!isGameOver(state) && steps < 2000) {
+        const actions = legalActions(state);
+        expect(actions.length).toBeGreaterThan(0);
+        const action = randomOf(actions, rng);
+        const res = applyAction(state, action);
+        expect(res.error).toBeUndefined();
+        state = res.state;
+        conservation(state, FOLLOWERS_PER_FACTION);
+        steps++;
+      }
+      expect(isGameOver(state)).toBe(true);
+      const result = gameResult(state)!;
+      expect(result.winnerIds.length).toBeGreaterThanOrEqual(1);
+      expect(["invasion", "coronation"]).toContain(result.ending);
+    }
+  });
+
+  it("summon options only ever come from regions", () => {
+    const state = newGame(P3, 55);
+    for (const o of summonOptions(state)) {
+      expect(REGION_IDS).toContain(o.regionId);
+      expect(state.regions[o.regionId].cubes[o.faction]).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/features/tkid2/engine/tkid2Engine.ts
+++ b/src/features/tkid2/engine/tkid2Engine.ts
@@ -1,131 +1,291 @@
 /**
- * TKID2 — "The King Is Dead: Second Edition" score/play engine.
+ * The King Is Dead: Second Edition — rules engine.
  *
- * ----------------------------------------------------------------------------
- * IMPORTANT — RULES INTERPRETATION
- * ----------------------------------------------------------------------------
- * The authoritative rulebook (BGG file `bgg280719`, "TKID2_rulebook.pdf") is
- * served from an expired S3 signed URL that could not be retrieved while this
- * engine was written. The mechanics below are therefore a *faithful
- * interpretation* of The King Is Dead: Second Edition, distilled from the
- * game's well-documented core loop. All tunable numbers live in the exported
- * constants near the top so they can be corrected against the real rulebook
- * without touching game logic.
+ * Implements the official Osprey Games rulebook (Peer Sylvester, 2020):
+ *   - 8 regions of Britain + France, 54 follower cubes (18 per faction).
+ *   - Every player holds the same eight single-use action cards (basic game)
+ *     or five basic + three secret cunning cards (advanced game).
+ *   - On your turn: play a card (resolve its effect, then summon a follower
+ *     from the board to your court) or pass. When all players pass in
+ *     sequence, a power struggle resolves the contested region — the region
+ *     card in the lowest-numbered space that is still face up.
+ *   - Majority faction takes control (control disc); tie/empty regions become
+ *     unstable (instability disc from France). Three instability discs on the
+ *     board end the game at once with a French invasion; resolving all eight
+ *     regions ends it with a coronation.
+ *   - Coronation: the player with the most followers of the most powerful
+ *     faction in court wins. Invasion: the player with the most complete sets
+ *     (one follower of each faction) wins.
  *
- * Core loop captured:
- *   - Three native factions fight for majority control across a set of regions:
- *       english, scottish, welsh.
- *   - Regions are contested one at a time in a (seeded) order.
- *   - On a turn a player either PLAYS one single-use action card (manipulating
- *     faction cubes in / around the contested region) or PASSES. Passing lets
- *     the player take one follower (a cube of a chosen faction present in the
- *     contested region) into their personal court, then removes them from the
- *     round.
- *   - When every player has passed, the contested region is RESOLVED: the
- *     faction with a strict cube majority earns that region's crown. A tie (or
- *     an empty region) leaves the region "in revolt" — a foreign (french)
- *     crown, which counts toward an invasion.
- *   - After all regions resolve, the game ends. If enough regions fell into
- *     revolt an INVASION flips the win condition (alignment with the *weakest*
- *     native faction wins); otherwise alignment with the *strongest* native
- *     faction wins.
- *
- * Design constraints (so a future online, turn-based multiplayer mode is an
- * add-on rather than a rewrite — mirroring `features/play/engine`):
- *   - Pure & framework-free: no React / Redux imports.
- *   - Serializable: every state value is plain JSON.
- *   - Deterministic: all randomness flows through a caller-supplied `seed`.
- *   - Action-based: all transitions go through `applyAction(state, action)`
- *     which returns a new state, emitted events, and an optional rejection
- *     reason. The UI and the AI both produce the same `TKID2Action` objects.
+ * Design constraints: pure, serializable, deterministic (seeded), and
+ * action-based so UI and AI both drive the game through `applyAction`.
  */
 
 // ===========================================================================
-// Tunable constants (correct these against the real rulebook if needed)
+// Factions & regions
 // ===========================================================================
 
-/** The three native factions competing for control. */
-export const FACTIONS = ["english", "scottish", "welsh"] as const;
+export const FACTIONS = ["scottish", "welsh", "english"] as const;
 export type Faction = (typeof FACTIONS)[number];
 
-/** The foreign power that benefits from unrest. Never held as a follower. */
-export const FOREIGN: "french" = "french";
+export const FACTION_LABEL: Record<Faction, string> = {
+  scottish: "Scottish",
+  welsh: "Welsh",
+  english: "English",
+};
 
-/** Owner of a resolved region's crown: a native faction or the foreign power. */
-export type CrownOwner = Faction | typeof FOREIGN;
-
-export type RegionId = string;
+export type RegionId =
+  | "moray"
+  | "strathclyde"
+  | "lancaster"
+  | "northumbria"
+  | "gwynedd"
+  | "warwick"
+  | "essex"
+  | "devon";
 
 export interface RegionDef {
   id: RegionId;
   name: string;
-  /** Ids of regions from which cubes may be manoeuvred into this one. */
   adjacent: RegionId[];
-  /** Starting cube counts per faction at game setup. */
-  setup: Record<Faction, number>;
 }
 
-/**
- * A compact map of Britain: eight regions with a simple adjacency graph and a
- * balanced opening cube layout. (Numbers/adjacency are an interpretation.)
- */
+/** The board of Britain: eight regions with the printed adjacency. */
 export const REGIONS: RegionDef[] = [
-  { id: "lothian", name: "Lothian", adjacent: ["strathclyde", "northumbria"], setup: { english: 0, scottish: 2, welsh: 0 } },
-  { id: "strathclyde", name: "Strathclyde", adjacent: ["lothian", "northumbria", "gwynedd"], setup: { english: 0, scottish: 2, welsh: 1 } },
-  { id: "northumbria", name: "Northumbria", adjacent: ["lothian", "strathclyde", "mercia"], setup: { english: 1, scottish: 1, welsh: 0 } },
-  { id: "gwynedd", name: "Gwynedd", adjacent: ["strathclyde", "mercia", "wessex"], setup: { english: 0, scottish: 1, welsh: 2 } },
-  { id: "mercia", name: "Mercia", adjacent: ["northumbria", "gwynedd", "wessex", "anglia"], setup: { english: 2, scottish: 0, welsh: 1 } },
-  { id: "anglia", name: "Anglia", adjacent: ["mercia", "wessex"], setup: { english: 2, scottish: 0, welsh: 0 } },
-  { id: "wessex", name: "Wessex", adjacent: ["gwynedd", "mercia", "anglia", "cornwall"], setup: { english: 2, scottish: 0, welsh: 1 } },
-  { id: "cornwall", name: "Cornwall", adjacent: ["wessex"], setup: { english: 1, scottish: 0, welsh: 1 } },
+  { id: "moray", name: "Moray", adjacent: ["strathclyde"] },
+  { id: "strathclyde", name: "Strathclyde", adjacent: ["moray", "lancaster", "northumbria"] },
+  { id: "lancaster", name: "Lancaster", adjacent: ["strathclyde", "northumbria", "gwynedd", "warwick"] },
+  { id: "northumbria", name: "Northumbria", adjacent: ["strathclyde", "lancaster", "warwick", "essex"] },
+  { id: "gwynedd", name: "Gwynedd", adjacent: ["lancaster", "warwick", "devon"] },
+  { id: "warwick", name: "Warwick", adjacent: ["lancaster", "northumbria", "gwynedd", "essex", "devon"] },
+  { id: "essex", name: "Essex", adjacent: ["northumbria", "warwick", "devon"] },
+  { id: "devon", name: "Devon", adjacent: ["gwynedd", "warwick", "essex"] },
 ];
 
-/**
- * Number of regions that must end in revolt (foreign crown) for the foreign
- * invasion to trigger and flip the win condition.
- */
-export const INVASION_THRESHOLD = 4;
+export const REGION_IDS = REGIONS.map((r) => r.id);
 
-/** How many cubes a "Muster" card adds to the contested region. */
-export const MUSTER_AMOUNT = 2;
-/** Maximum cubes a "Exile" card removes from the contested region. */
-export const EXILE_AMOUNT = 2;
-/** Maximum cubes a single "Manoeuvre" card moves in from an adjacent region. */
-export const MANOEUVRE_AMOUNT = 2;
+const REGION_BY_ID: Record<RegionId, RegionDef> = Object.fromEntries(
+  REGIONS.map((r) => [r.id, r]),
+) as Record<RegionId, RegionDef>;
+
+export function regionName(id: RegionId): string {
+  return REGION_BY_ID[id].name;
+}
+
+export function areAdjacent(a: RegionId, b: RegionId): boolean {
+  return REGION_BY_ID[a].adjacent.includes(b);
+}
+
+/** Home region of each faction (used by Support and cunning cards). */
+export const HOME_REGION: Record<Faction, RegionId> = {
+  scottish: "moray",
+  welsh: "gwynedd",
+  english: "essex",
+};
+
+/** Followers per faction in the box (16 each in a two-player game). */
+export const FOLLOWERS_PER_FACTION = 18;
+export const FOLLOWERS_PER_FACTION_2P = 16;
+/** Followers in every region after setup. */
+export const SETUP_FOLLOWERS_PER_REGION = 4;
+/** Instability discs waiting in France; when the third hits the board → invasion. */
+export const INSTABILITY_DISCS = 3;
 
 // ===========================================================================
 // Cards
 // ===========================================================================
 
-export type ActionCardKind = "muster" | "exile" | "manoeuvre";
+export type BaseCardId =
+  | "scottish-support"
+  | "welsh-support"
+  | "english-support"
+  | "assemble-1"
+  | "assemble-2"
+  | "negotiate"
+  | "manoeuvre"
+  | "outmanoeuvre";
 
-export interface ActionCard {
-  /** Stable id, unique within a player's hand. */
-  id: string;
-  kind: ActionCardKind;
-  /** For muster/exile: the faction the card acts on. Null for manoeuvre. */
-  faction: Faction | null;
-  label: string;
+export type CunningCardId =
+  | "spy"
+  | "ambush"
+  | "march"
+  | "plot"
+  | "aid"
+  | "influence"
+  | "dispute"
+  | "edict"
+  | "resist"
+  | "quell"
+  | "suppress"
+  | "muster";
+
+export type CardId = BaseCardId | CunningCardId;
+
+export interface CardInfo {
+  id: CardId;
+  name: string;
+  cunning: boolean;
+  /** Rules text (abridged from the rulebook). */
+  text: string;
 }
 
-/**
- * The identical eight-card hand every player starts with:
- *   3× Muster   (one per faction) — reinforce a faction in the contested region
- *   3× Exile    (one per faction) — weaken a faction in the contested region
- *   2× Manoeuvre                  — pull one faction's cubes in from a neighbour
- */
-export function startingHand(): ActionCard[] {
-  const cards: ActionCard[] = [];
-  for (const f of FACTIONS) {
-    cards.push({ id: `muster-${f}`, kind: "muster", faction: f, label: `Muster ${cap(f)}` });
-  }
-  for (const f of FACTIONS) {
-    cards.push({ id: `exile-${f}`, kind: "exile", faction: f, label: `Exile ${cap(f)}` });
-  }
-  cards.push({ id: "manoeuvre-1", kind: "manoeuvre", faction: null, label: "Manoeuvre" });
-  cards.push({ id: "manoeuvre-2", kind: "manoeuvre", faction: null, label: "Manoeuvre" });
-  return cards;
-}
+export const CARD_INFO: Record<CardId, CardInfo> = {
+  "scottish-support": {
+    id: "scottish-support",
+    name: "Scottish Support",
+    cunning: false,
+    text: "Place two Scottish followers from the supply into a region that borders a region controlled by the Scots. If there is no control or instability disc in Moray, you may instead place them into a region bordering Moray.",
+  },
+  "welsh-support": {
+    id: "welsh-support",
+    name: "Welsh Support",
+    cunning: false,
+    text: "Place two Welsh followers from the supply into a region that borders a region controlled by the Welsh. If there is no control or instability disc in Gwynedd, you may instead place them into a region bordering Gwynedd.",
+  },
+  "english-support": {
+    id: "english-support",
+    name: "English Support",
+    cunning: false,
+    text: "Place two English followers from the supply into a region that borders a region controlled by the English. If there is no control or instability disc in Essex, you may instead place them into a region bordering Essex.",
+  },
+  "assemble-1": {
+    id: "assemble-1",
+    name: "Assemble",
+    cunning: false,
+    text: "Place a Scottish follower, a Welsh follower, and an English follower from the supply into any region or regions.",
+  },
+  "assemble-2": {
+    id: "assemble-2",
+    name: "Assemble",
+    cunning: false,
+    text: "Place a Scottish follower, a Welsh follower, and an English follower from the supply into any region or regions.",
+  },
+  negotiate: {
+    id: "negotiate",
+    name: "Negotiate",
+    cunning: false,
+    text: "Swap the positions of any two face-up region cards. Place a negotiation disc on one of the cards you swapped. Cards that are face down or already carry a negotiation disc cannot be swapped.",
+  },
+  manoeuvre: {
+    id: "manoeuvre",
+    name: "Manoeuvre",
+    cunning: false,
+    text: "Swap a follower in any region with a follower in any other region.",
+  },
+  outmanoeuvre: {
+    id: "outmanoeuvre",
+    name: "Outmanoeuvre",
+    cunning: false,
+    text: "Swap a follower in any region with two followers in a bordering region.",
+  },
+  spy: {
+    id: "spy",
+    name: "Spy",
+    cunning: true,
+    text: "Resolve the effect of an action card that is face up on top of another player's discard pile.",
+  },
+  ambush: {
+    id: "ambush",
+    name: "Ambush",
+    cunning: true,
+    text: "Place two Scottish followers from the supply into a region, then return a follower from that region to the supply.",
+  },
+  march: {
+    id: "march",
+    name: "March",
+    cunning: true,
+    text: "Move two followers from a single region to a single bordering region.",
+  },
+  plot: {
+    id: "plot",
+    name: "Plot",
+    cunning: true,
+    text: "You cannot take this action during the game. When deciding the winner, reveal this card: it counts as a follower of a faction of your choice.",
+  },
+  aid: {
+    id: "aid",
+    name: "Aid",
+    cunning: true,
+    text: "Find the faction with the most followers in the supply. Place two followers of that faction into any region.",
+  },
+  influence: {
+    id: "influence",
+    name: "Influence",
+    cunning: true,
+    text: "Swap one English follower in any region with two non-English followers in another region.",
+  },
+  dispute: {
+    id: "dispute",
+    name: "Dispute",
+    cunning: true,
+    text: "Swap a Welsh follower in any region with a non-Welsh follower in another region.",
+  },
+  edict: {
+    id: "edict",
+    name: "Edict",
+    cunning: true,
+    text: "Swap two Scottish followers in any region with two non-Scottish followers in a bordering region.",
+  },
+  resist: {
+    id: "resist",
+    name: "Resist",
+    cunning: true,
+    text: "Place two non-Scottish followers from the supply into any region that borders a region controlled by the Scots. If there is no control or instability disc in Moray, you may instead place them into a region bordering Moray.",
+  },
+  quell: {
+    id: "quell",
+    name: "Quell",
+    cunning: true,
+    text: "Return a Welsh follower to the supply from any region that borders a region controlled by the Welsh, then place two followers from the supply into that region. If there is no control or instability disc in Gwynedd, you may instead act in a region bordering Gwynedd.",
+  },
+  suppress: {
+    id: "suppress",
+    name: "Suppress",
+    cunning: true,
+    text: "Return an English follower to the supply from any region that borders a region controlled by the English, then return another follower from that region, then place a follower from the supply into that region. If there is no control or instability disc in Essex, you may instead act in a region bordering Essex.",
+  },
+  muster: {
+    id: "muster",
+    name: "Muster",
+    cunning: true,
+    text: "Return a Scottish follower to the supply from any region that borders a region controlled by the Scots, then place two followers from the supply into that region. If there is no control or instability disc in Moray, you may instead act in a region bordering Moray.",
+  },
+};
+
+export const BASE_HAND: BaseCardId[] = [
+  "scottish-support",
+  "welsh-support",
+  "english-support",
+  "assemble-1",
+  "assemble-2",
+  "negotiate",
+  "manoeuvre",
+  "outmanoeuvre",
+];
+
+/** Basic cards kept in the advanced game (supports are removed). */
+export const ADVANCED_BASE_HAND: BaseCardId[] = [
+  "assemble-1",
+  "assemble-2",
+  "negotiate",
+  "manoeuvre",
+  "outmanoeuvre",
+];
+
+export const CUNNING_DECK: CunningCardId[] = [
+  "spy",
+  "ambush",
+  "march",
+  "plot",
+  "aid",
+  "influence",
+  "dispute",
+  "edict",
+  "resist",
+  "quell",
+  "suppress",
+  "muster",
+];
 
 // ===========================================================================
 // State
@@ -133,100 +293,142 @@ export function startingHand(): ActionCard[] {
 
 export type PlayerId = string;
 
-export interface TKID2Player {
+export type FactionCounts = Record<Faction, number>;
+
+export interface RegionState {
+  cubes: FactionCounts;
+  /** Faction that won this region's power struggle (control disc). */
+  control: Faction | null;
+  /** True when the power struggle tied / was empty (instability disc). */
+  unstable: boolean;
+}
+
+/** One of the eight numbered spaces around the board, holding a region card. */
+export interface BoardSlot {
+  /** Printed number 1–8; struggles resolve lowest face-up number first. */
+  position: number;
+  regionId: RegionId;
+  faceUp: boolean;
+  negotiationDisc: boolean;
+}
+
+export interface Tkid2Player {
   id: PlayerId;
   name: string;
   isBot: boolean;
-  /** Ids of action cards still in hand (single-use). */
-  hand: string[];
-  /** Follower cubes collected into this player's personal court. */
-  court: Record<Faction, number>;
-  /** Whether this player has passed out of the current round. */
-  passed: boolean;
+  hand: CardId[];
+  /** Played cards, last = top of the (face-up) discard pile. */
+  discard: CardId[];
+  court: FactionCounts;
+  /** Global action sequence number of this player's most recent card play. */
+  lastActionSeq: number;
+  /** Sequence at which the hand became empty (null = still holds cards). */
+  emptyHandSeq: number | null;
 }
 
-export type Phase = "in-progress" | "ended";
+export type Ending = "invasion" | "coronation";
 
-export interface TKID2State {
-  players: TKID2Player[];
-  /** Current cube counts per region. */
-  regions: Record<RegionId, Record<Faction, number>>;
-  /** Order in which regions are contested (seeded shuffle of region ids). */
-  eventOrder: RegionId[];
-  /** Index into `eventOrder` of the region being contested right now. */
-  eventIndex: number;
-  /** Resolved crowns: regionId → owning faction / foreign power. */
-  crowns: Record<RegionId, CrownOwner>;
-  /** Index into `players` whose turn it is. */
+export interface SwapRecord {
+  kind: "manoeuvre" | "outmanoeuvre";
+  playerIndex: number;
+  seq: number;
+  from: { regionId: RegionId; factions: Faction[] };
+  to: { regionId: RegionId; factions: Faction[] };
+}
+
+export interface StruggleRecord {
+  regionId: RegionId;
+  outcome: Faction | "unstable";
+  /** Followers in the region at resolution (for the log/UI). */
+  cubes: FactionCounts;
+}
+
+export interface Tkid2State {
+  players: Tkid2Player[];
+  regions: Record<RegionId, RegionState>;
+  slots: BoardSlot[];
+  supply: FactionCounts;
+  /** Instability discs still waiting in France (starts at 3). */
+  instabilityInFrance: number;
   currentPlayerIndex: number;
-  phase: Phase;
-  /** Seed the game was created with (kept for replay / online sync). */
+  consecutivePasses: number;
+  /** True while the current player must summon a follower after a card play. */
+  pendingSummon: boolean;
+  /** Number of action cards played so far, by anyone. */
+  actionSeq: number;
+  /** Most recent (out)manoeuvre swap, for the "cannot undo" rule. */
+  lastSwap: SwapRecord | null;
+  struggles: StruggleRecord[];
+  phase: "playing" | "ended";
+  ending: Ending | null;
+  advanced: boolean;
   seed: number;
 }
 
 // ===========================================================================
-// Actions & events
+// Actions
 // ===========================================================================
 
-export type TKID2Action =
-  | {
-      type: "playCard";
-      cardId: string;
-      /** Manoeuvre only: the neighbouring region to pull cubes from. */
-      fromRegion?: RegionId;
-      /** Manoeuvre only: which faction's cubes to move. */
-      faction?: Faction;
-    }
-  | {
-      type: "pass";
-      /** Faction whose cube to take as a follower (must be present in region). */
-      takeFollower?: Faction;
-    };
+export interface SwapSide {
+  regionId: RegionId;
+  factions: Faction[];
+}
 
-export type TKID2Event =
-  | { kind: "cardPlayed"; playerId: PlayerId; cardId: string; region: RegionId }
-  | { kind: "passed"; playerId: PlayerId; tookFollower: Faction | null }
-  | { kind: "regionResolved"; region: RegionId; owner: CrownOwner }
-  | { kind: "gameEnded" };
+export interface Placement {
+  regionId: RegionId;
+  faction: Faction;
+}
+
+/**
+ * Parameters accompanying a card play. Which fields matter depends on the
+ * card; `enumerateCardParams` produces every legal assignment.
+ */
+export interface CardParams {
+  /** Target region (support, ambush, aid, resist, quell, suppress, muster). */
+  regionId?: RegionId;
+  /** Aid: which (tied-)largest supply faction to draw from. */
+  faction?: Faction;
+  /** Assemble / resist / quell / muster / suppress: supply placements. */
+  placements?: Placement[];
+  /** Ambush / quell / muster / suppress: followers returned to the supply. */
+  returnFactions?: Faction[];
+  /** Negotiate: positions (1–8) of the two cards to swap. */
+  slotA?: number;
+  slotB?: number;
+  /** Negotiate: which of the two swapped region cards gets the disc. */
+  discRegionId?: RegionId;
+  /** Swaps and March. */
+  from?: SwapSide;
+  to?: SwapSide;
+  /** Spy. */
+  spyPlayerId?: PlayerId;
+  spyParams?: CardParams;
+}
+
+export type Tkid2Action =
+  | { type: "pass" }
+  | { type: "play"; cardId: CardId; params: CardParams }
+  | { type: "summon"; regionId: RegionId; faction: Faction };
+
+export type Tkid2Event =
+  | { kind: "played"; playerId: PlayerId; cardId: CardId; viaSpy?: boolean }
+  | { kind: "summoned"; playerId: PlayerId; regionId: RegionId; faction: Faction }
+  | { kind: "summonSkipped"; playerId: PlayerId }
+  | { kind: "passed"; playerId: PlayerId }
+  | { kind: "struggle"; record: StruggleRecord }
+  | { kind: "invasion" }
+  | { kind: "coronation" };
 
 export interface ApplyResult {
-  state: TKID2State;
-  events: TKID2Event[];
-  /** When set, the action was rejected and `state` is unchanged. */
+  state: Tkid2State;
+  events: Tkid2Event[];
+  /** When set, the action was rejected and `state` is the original state. */
   error?: string;
 }
 
 // ===========================================================================
-// Setup
+// Seeded RNG
 // ===========================================================================
-
-export interface SetupPlayer {
-  id: PlayerId;
-  name: string;
-  isBot: boolean;
-}
-
-const REGION_BY_ID: Record<RegionId, RegionDef> = Object.fromEntries(
-  REGIONS.map((r) => [r.id, r]),
-) as Record<RegionId, RegionDef>;
-
-function emptyCourt(): Record<Faction, number> {
-  return { english: 0, scottish: 0, welsh: 0 };
-}
-
-/**
- * Deterministic Fisher–Yates shuffle driven by a seed (mulberry32). Kept local
- * so the engine has no cross-feature dependency.
- */
-export function seededShuffle<T>(input: readonly T[], seed: number): T[] {
-  const arr = input.slice();
-  const rng = mulberry32(seed);
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr;
-}
 
 function mulberry32(seed: number): () => number {
   let a = seed >>> 0;
@@ -239,266 +441,1099 @@ function mulberry32(seed: number): () => number {
   };
 }
 
-export function newGame(players: SetupPlayer[], seed = 1): TKID2State {
+export function seededShuffle<T>(input: readonly T[], seed: number): T[] {
+  const arr = input.slice();
+  const rng = mulberry32(seed);
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+// ===========================================================================
+// Setup
+// ===========================================================================
+
+export interface SetupPlayer {
+  id: PlayerId;
+  name: string;
+  isBot: boolean;
+}
+
+export interface SetupOptions {
+  /** Advanced game: no Support cards, three secret cunning cards each. */
+  advanced?: boolean;
+}
+
+function zeroCounts(): FactionCounts {
+  return { scottish: 0, welsh: 0, english: 0 };
+}
+
+export function totalCubes(c: FactionCounts): number {
+  return c.scottish + c.welsh + c.english;
+}
+
+function drawFromBag(bag: FactionCounts, rng: () => number): Faction | null {
+  const total = totalCubes(bag);
+  if (total === 0) return null;
+  let pick = Math.floor(rng() * total);
+  for (const f of FACTIONS) {
+    if (pick < bag[f]) {
+      bag[f] -= 1;
+      return f;
+    }
+    pick -= bag[f];
+  }
+  return null;
+}
+
+export function newGame(
+  players: SetupPlayer[],
+  seed = 1,
+  options: SetupOptions = {},
+): Tkid2State {
   if (players.length < 2 || players.length > 4) {
-    throw new Error("TKID2 supports 2–4 players");
+    throw new Error("The King Is Dead supports 2-4 players");
   }
-  const regions: Record<RegionId, Record<Faction, number>> = {};
+  const advanced = options.advanced === true;
+  const rng = mulberry32((seed ^ 0x9e3779b9) >>> 0);
+
+  const perFaction =
+    players.length === 2 ? FOLLOWERS_PER_FACTION_2P : FOLLOWERS_PER_FACTION;
+
+  // Home regions: two followers of each faction start at home.
+  const regions: Record<RegionId, RegionState> = {} as Record<
+    RegionId,
+    RegionState
+  >;
   for (const r of REGIONS) {
-    regions[r.id] = { ...r.setup };
+    regions[r.id] = { cubes: zeroCounts(), control: null, unstable: false };
   }
-  const eventOrder = seededShuffle(
-    REGIONS.map((r) => r.id),
-    seed,
-  );
+  const bag: FactionCounts = {
+    scottish: perFaction,
+    welsh: perFaction,
+    english: perFaction,
+  };
+  for (const f of FACTIONS) {
+    regions[HOME_REGION[f]].cubes[f] += 2;
+    bag[f] -= 2;
+  }
+
+  // Each player draws two random followers into their court.
+  const courts: FactionCounts[] = players.map(() => zeroCounts());
+  for (const court of courts) {
+    for (let i = 0; i < 2; i++) {
+      const f = drawFromBag(bag, rng);
+      if (f) court[f] += 1;
+    }
+  }
+
+  // Fill every region up to four random followers.
+  for (const r of REGIONS) {
+    while (totalCubes(regions[r.id].cubes) < SETUP_FOLLOWERS_PER_REGION) {
+      const f = drawFromBag(bag, rng);
+      if (!f) break;
+      regions[r.id].cubes[f] += 1;
+    }
+  }
+
+  // Region cards: shuffled onto the numbered spaces 1-8.
+  const order = seededShuffle(REGION_IDS, seed);
+  const slots: BoardSlot[] = order.map((regionId, i) => ({
+    position: i + 1,
+    regionId,
+    faceUp: true,
+    negotiationDisc: false,
+  }));
+
+  // Hands: basic or advanced. Cunning cards are dealt from one shuffled deck.
+  const cunning = seededShuffle(CUNNING_DECK, (seed ^ 0x51ab3c) >>> 0);
+  const mkHand = (idx: number): CardId[] =>
+    advanced
+      ? [...ADVANCED_BASE_HAND, ...cunning.slice(idx * 3, idx * 3 + 3)]
+      : [...BASE_HAND];
+
   return {
-    players: players.map((p) => ({
+    players: players.map((p, i) => ({
       id: p.id,
       name: p.name,
       isBot: p.isBot,
-      hand: startingHand().map((c) => c.id),
-      court: emptyCourt(),
-      passed: false,
+      hand: mkHand(i),
+      discard: [],
+      court: courts[i],
+      lastActionSeq: -1,
+      emptyHandSeq: null,
     })),
     regions,
-    eventOrder,
-    eventIndex: 0,
-    crowns: {},
+    slots,
+    supply: bag,
+    instabilityInFrance: INSTABILITY_DISCS,
     currentPlayerIndex: 0,
-    phase: "in-progress",
+    consecutivePasses: 0,
+    pendingSummon: false,
+    actionSeq: 0,
+    lastSwap: null,
+    struggles: [],
+    phase: "playing",
+    ending: null,
+    advanced,
     seed,
   };
 }
 
 // ===========================================================================
-// Selectors / helpers
+// Selectors
 // ===========================================================================
 
-export function currentRegionId(state: TKID2State): RegionId | null {
-  if (state.eventIndex >= state.eventOrder.length) return null;
-  return state.eventOrder[state.eventIndex];
+export function currentPlayer(state: Tkid2State): Tkid2Player {
+  return state.players[state.currentPlayerIndex] ?? state.players[0];
 }
 
-export function currentPlayer(state: TKID2State): TKID2Player {
-  if (state.players.length === 0) {
-    throw new Error("TKID2State has no players");
-  }
-  const idx = state.currentPlayerIndex;
-  if (idx < 0 || idx >= state.players.length) {
-    // Defensive: a well-formed state never has an out-of-range index, but
-    // fall back to the first player rather than returning undefined.
-    return state.players[0];
-  }
-  return state.players[idx];
+export function isGameOver(state: Tkid2State): boolean {
+  return state.phase === "ended";
 }
 
-export function cardById(id: string): ActionCard | undefined {
-  return startingHand().find((c) => c.id === id);
+/** A region is open while it has neither a control nor an instability disc. */
+export function isOpen(state: Tkid2State, id: RegionId): boolean {
+  const r = state.regions[id];
+  return r.control === null && !r.unstable;
 }
 
-export function regionCubes(
-  state: TKID2State,
-  regionId: RegionId,
-): Record<Faction, number> {
-  return state.regions[regionId];
+/** The region whose power struggle resolves next (lowest face-up space). */
+export function contestedRegionId(state: Tkid2State): RegionId | null {
+  const slot = state.slots.find((s) => s.faceUp);
+  return slot ? slot.regionId : null;
 }
 
-/** Faction(s) with the most cubes in a region. */
-export function regionLeaders(cubes: Record<Faction, number>): Faction[] {
+/** Faction with a strict follower majority in the counts, else null. */
+export function majorityFaction(cubes: FactionCounts): Faction | null {
   const max = Math.max(...FACTIONS.map((f) => cubes[f]));
-  if (max <= 0) return [];
-  return FACTIONS.filter((f) => cubes[f] === max);
+  if (max === 0) return null;
+  const leaders = FACTIONS.filter((f) => cubes[f] === max);
+  return leaders.length === 1 ? leaders[0] : null;
 }
 
-/** The owner a region would get if resolved right now. */
-export function projectedOwner(cubes: Record<Faction, number>): CrownOwner {
-  const leaders = regionLeaders(cubes);
-  return leaders.length === 1 ? leaders[0] : FOREIGN;
+/** Instability discs already placed on the board. */
+export function instabilityOnBoard(state: Tkid2State): number {
+  return INSTABILITY_DISCS - state.instabilityInFrance;
 }
 
-// ===========================================================================
-// Legal-move enumeration (used by the UI and the AI)
-// ===========================================================================
-
-/**
- * All legal actions for the current player. Pass options are enumerated one
- * per takeable follower colour (plus a bare pass when the region is empty).
- */
-export function legalActions(state: TKID2State): TKID2Action[] {
-  if (state.phase === "ended") return [];
-  const region = currentRegionId(state);
-  if (region === null) return [];
-  const player = currentPlayer(state);
-  if (player.passed) return [];
-
-  const actions: TKID2Action[] = [];
-  const cubes = state.regions[region];
-
-  // Pass — optionally taking one follower of a colour present in the region.
-  const takeable = FACTIONS.filter((f) => cubes[f] > 0);
-  if (takeable.length === 0) {
-    actions.push({ type: "pass" });
-  } else {
-    for (const f of takeable) actions.push({ type: "pass", takeFollower: f });
+/** Regions currently controlled by each faction. */
+export function controlledCounts(state: Tkid2State): FactionCounts {
+  const counts = zeroCounts();
+  for (const id of REGION_IDS) {
+    const c = state.regions[id].control;
+    if (c) counts[c] += 1;
   }
+  return counts;
+}
 
-  // Card plays.
-  for (const cardId of player.hand) {
-    const card = cardById(cardId);
-    if (!card) continue;
-    if (card.kind === "muster") {
-      actions.push({ type: "playCard", cardId });
-    } else if (card.kind === "exile") {
-      // Only useful if that faction has cubes to remove.
-      if (card.faction && cubes[card.faction] > 0) {
-        actions.push({ type: "playCard", cardId });
+/** Open regions that border a region controlled by `faction`, or — while the
+ *  faction's home region is open — regions bordering its home region. */
+export function supportTargets(state: Tkid2State, faction: Faction): RegionId[] {
+  const targets = new Set<RegionId>();
+  for (const r of REGIONS) {
+    if (!isOpen(state, r.id)) continue;
+    const bordersControlled = r.adjacent.some(
+      (a) => state.regions[a].control === faction,
+    );
+    const bordersOpenHome =
+      isOpen(state, HOME_REGION[faction]) &&
+      r.adjacent.includes(HOME_REGION[faction]);
+    if (bordersControlled || bordersOpenHome) targets.add(r.id);
+  }
+  return Array.from(targets);
+}
+
+/** All (region, faction) pairs from which a follower can be summoned. */
+export function summonOptions(
+  state: Tkid2State,
+): { regionId: RegionId; faction: Faction }[] {
+  const out: { regionId: RegionId; faction: Faction }[] = [];
+  for (const id of REGION_IDS) {
+    for (const f of FACTIONS) {
+      if (state.regions[id].cubes[f] > 0) out.push({ regionId: id, faction: f });
+    }
+  }
+  return out;
+}
+
+// ===========================================================================
+// Card parameter enumeration
+// ===========================================================================
+// For every card we enumerate candidate parameter assignments together with a
+// "completeness" score. The rulebook requires resolving an action as fully as
+// possible, so only the maximum-score candidates are legal. An empty list
+// means the card can only be played for no effect (params: {}).
+
+interface Candidate {
+  params: CardParams;
+  score: number;
+}
+
+function canonFactions(fs: Faction[]): Faction[] {
+  return [...fs].sort();
+}
+
+/** Canonical serialization so params can be compared for legality. */
+export function canonicalParams(cardId: CardId, params: CardParams): string {
+  const p: CardParams = { ...params };
+  if (p.from) p.from = { ...p.from, factions: canonFactions(p.from.factions) };
+  if (p.to) p.to = { ...p.to, factions: canonFactions(p.to.factions) };
+  if (p.returnFactions) p.returnFactions = canonFactions(p.returnFactions);
+  if (p.placements) {
+    p.placements = [...p.placements].sort((a, b) =>
+      (a.regionId + a.faction).localeCompare(b.regionId + b.faction),
+    );
+  }
+  if (p.slotA !== undefined && p.slotB !== undefined && p.slotA > p.slotB) {
+    const t = p.slotA;
+    p.slotA = p.slotB;
+    p.slotB = t;
+  }
+  if (cardId === "manoeuvre" && p.from && p.to) {
+    // The 1↔1 swap is symmetric; order the sides by region id.
+    if (p.from.regionId > p.to.regionId) {
+      const t = p.from;
+      p.from = p.to;
+      p.to = t;
+    }
+  }
+  const spy = p.spyParams ? canonicalParams("spy", p.spyParams) : "";
+  return JSON.stringify([
+    p.regionId ?? "",
+    p.faction ?? "",
+    p.placements ?? [],
+    p.returnFactions ?? [],
+    p.slotA ?? -1,
+    p.slotB ?? -1,
+    p.discRegionId ?? "",
+    p.from ?? null,
+    p.to ?? null,
+    p.spyPlayerId ?? "",
+    spy,
+  ]);
+}
+
+function openRegions(state: Tkid2State): RegionId[] {
+  return REGION_IDS.filter((id) => isOpen(state, id));
+}
+
+function regionsWithCubes(state: Tkid2State): RegionId[] {
+  return REGION_IDS.filter((id) => totalCubes(state.regions[id].cubes) > 0);
+}
+
+/** Distinct multisets of `n` factions available in `counts` (optionally from a
+ *  restricted faction pool). */
+function factionMultisets(
+  counts: FactionCounts,
+  n: number,
+  pool: Faction[] = [...FACTIONS],
+): Faction[][] {
+  const out: Faction[][] = [];
+  const rec = (start: number, remaining: number, acc: Faction[], used: FactionCounts) => {
+    if (remaining === 0) {
+      out.push([...acc]);
+      return;
+    }
+    for (let i = start; i < pool.length; i++) {
+      const f = pool[i];
+      if (used[f] < counts[f]) {
+        used[f] += 1;
+        acc.push(f);
+        rec(i, remaining - 1, acc, used);
+        acc.pop();
+        used[f] -= 1;
       }
-    } else {
-      // Manoeuvre: for each adjacent region and each faction present there.
-      const def = REGION_BY_ID[region];
-      for (const adj of def.adjacent) {
-        const adjCubes = state.regions[adj];
-        for (const f of FACTIONS) {
-          if (adjCubes[f] > 0) {
-            actions.push({ type: "playCard", cardId, fromRegion: adj, faction: f });
+    }
+  };
+  rec(0, n, [], zeroCounts());
+  return out;
+}
+
+function supportCandidates(state: Tkid2State, faction: Faction): Candidate[] {
+  const amount = Math.min(2, state.supply[faction]);
+  if (amount === 0) return [];
+  const targets = supportTargets(state, faction);
+  return targets.map((regionId) => ({
+    params: {
+      regionId,
+      placements: Array.from({ length: amount }, () => ({ regionId, faction })),
+    },
+    score: amount,
+  }));
+}
+
+function assembleCandidates(state: Tkid2State): Candidate[] {
+  const open = openRegions(state);
+  if (open.length === 0) return [];
+  const available = FACTIONS.filter((f) => state.supply[f] > 0);
+  if (available.length === 0) return [];
+  const out: Candidate[] = [];
+  const rec = (i: number, acc: Placement[]) => {
+    if (i === available.length) {
+      out.push({ params: { placements: [...acc] }, score: acc.length });
+      return;
+    }
+    for (const regionId of open) {
+      acc.push({ regionId, faction: available[i] });
+      rec(i + 1, acc);
+      acc.pop();
+    }
+  };
+  rec(0, []);
+  return out;
+}
+
+function negotiateCandidates(state: Tkid2State): Candidate[] {
+  const eligible = state.slots.filter((s) => s.faceUp && !s.negotiationDisc);
+  if (eligible.length < 2) return [];
+  const out: Candidate[] = [];
+  for (let i = 0; i < eligible.length; i++) {
+    for (let j = i + 1; j < eligible.length; j++) {
+      for (const disc of [eligible[i].regionId, eligible[j].regionId]) {
+        out.push({
+          params: {
+            slotA: eligible[i].position,
+            slotB: eligible[j].position,
+            discRegionId: disc,
+          },
+          score: 1,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+/** True when `candidate` would exactly reverse the previous swap made by
+ *  another player with no card play in between. */
+function isForbiddenUndo(
+  state: Tkid2State,
+  kind: "manoeuvre" | "outmanoeuvre",
+  from: SwapSide,
+  to: SwapSide,
+): boolean {
+  const last = state.lastSwap;
+  if (!last || last.kind !== kind) return false;
+  if (last.playerIndex === state.currentPlayerIndex) return false;
+  if (last.seq !== state.actionSeq) return false; // another action intervened
+  const same = (a: Faction[], b: Faction[]) =>
+    a.length === b.length &&
+    canonFactions(a).every((f, i) => f === canonFactions(b)[i]);
+  if (kind === "manoeuvre") {
+    // Undo of A.x↔B.y is swapping the moved cubes back: A.y↔B.x.
+    return (
+      ((from.regionId === last.from.regionId &&
+        to.regionId === last.to.regionId &&
+        same(from.factions, last.to.factions) &&
+        same(to.factions, last.from.factions)) ||
+        (from.regionId === last.to.regionId &&
+          to.regionId === last.from.regionId &&
+          same(from.factions, last.from.factions) &&
+          same(to.factions, last.to.factions)))
+    );
+  }
+  // Outmanoeuvre: undo of from=(A,[x]) to=(B,[y,z]) is from=(B,[x]) to=(A,[y,z]).
+  return (
+    from.regionId === last.to.regionId &&
+    to.regionId === last.from.regionId &&
+    same(from.factions, last.from.factions) &&
+    same(to.factions, last.to.factions)
+  );
+}
+
+function manoeuvreCandidates(state: Tkid2State): Candidate[] {
+  const regions = regionsWithCubes(state).filter((id) => isOpen(state, id));
+  const out: Candidate[] = [];
+  for (let i = 0; i < regions.length; i++) {
+    for (let j = i + 1; j < regions.length; j++) {
+      const a = regions[i];
+      const b = regions[j];
+      for (const fa of FACTIONS) {
+        if (state.regions[a].cubes[fa] === 0) continue;
+        for (const fb of FACTIONS) {
+          if (state.regions[b].cubes[fb] === 0) continue;
+          const from = { regionId: a, factions: [fa] };
+          const to = { regionId: b, factions: [fb] };
+          if (isForbiddenUndo(state, "manoeuvre", from, to)) continue;
+          out.push({ params: { from, to }, score: 1 });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function outmanoeuvreCandidates(state: Tkid2State): Candidate[] {
+  const out: Candidate[] = [];
+  for (const a of REGION_IDS) {
+    if (!isOpen(state, a) || totalCubes(state.regions[a].cubes) === 0) continue;
+    for (const b of REGION_BY_ID[a].adjacent) {
+      if (!isOpen(state, b)) continue;
+      for (const fa of FACTIONS) {
+        if (state.regions[a].cubes[fa] === 0) continue;
+        // Full swap: one follower from A for two followers in B.
+        for (const pair of factionMultisets(state.regions[b].cubes, 2)) {
+          const from = { regionId: a, factions: [fa] };
+          const to = { regionId: b, factions: pair };
+          if (isForbiddenUndo(state, "outmanoeuvre", from, to)) continue;
+          out.push({ params: { from, to }, score: 2 });
+        }
+        // Partial: one for one (only legal when no full swap exists anywhere —
+        // the max-score filter takes care of that).
+        for (const fb of FACTIONS) {
+          if (state.regions[b].cubes[fb] === 0) continue;
+          const from = { regionId: a, factions: [fa] };
+          const to = { regionId: b, factions: [fb] };
+          if (isForbiddenUndo(state, "outmanoeuvre", from, to)) continue;
+          out.push({ params: { from, to }, score: 1 });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function ambushCandidates(state: Tkid2State): Candidate[] {
+  const amount = Math.min(2, state.supply.scottish);
+  const out: Candidate[] = [];
+  for (const regionId of openRegions(state)) {
+    // Weight placements above the return so "place two" is never skipped.
+    const placeScore = amount * 4;
+    const cubesAfter: FactionCounts = { ...state.regions[regionId].cubes };
+    cubesAfter.scottish += amount;
+    let any = false;
+    for (const f of FACTIONS) {
+      if (cubesAfter[f] > 0) {
+        any = true;
+        out.push({
+          params: {
+            regionId,
+            placements: Array.from({ length: amount }, () => ({
+              regionId,
+              faction: "scottish" as Faction,
+            })),
+            returnFactions: [f],
+          },
+          score: placeScore + 1,
+        });
+      }
+    }
+    if (!any && amount > 0) {
+      out.push({
+        params: {
+          regionId,
+          placements: Array.from({ length: amount }, () => ({
+            regionId,
+            faction: "scottish" as Faction,
+          })),
+          returnFactions: [],
+        },
+        score: placeScore,
+      });
+    }
+  }
+  return out;
+}
+
+function marchCandidates(state: Tkid2State): Candidate[] {
+  const out: Candidate[] = [];
+  for (const a of REGION_IDS) {
+    const cubes = state.regions[a].cubes;
+    if (totalCubes(cubes) === 0) continue;
+    for (const b of REGION_BY_ID[a].adjacent) {
+      if (!isOpen(state, b)) continue;
+      for (const pair of factionMultisets(cubes, 2)) {
+        out.push({
+          params: { from: { regionId: a, factions: pair }, to: { regionId: b, factions: [] } },
+          score: 2,
+        });
+      }
+      for (const f of FACTIONS) {
+        if (cubes[f] === 0) continue;
+        out.push({
+          params: { from: { regionId: a, factions: [f] }, to: { regionId: b, factions: [] } },
+          score: 1,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function aidCandidates(state: Tkid2State): Candidate[] {
+  const max = Math.max(...FACTIONS.map((f) => state.supply[f]));
+  if (max === 0) return [];
+  const factions = FACTIONS.filter((f) => state.supply[f] === max);
+  const out: Candidate[] = [];
+  for (const faction of factions) {
+    const amount = Math.min(2, state.supply[faction]);
+    for (const regionId of openRegions(state)) {
+      out.push({
+        params: {
+          regionId,
+          faction,
+          placements: Array.from({ length: amount }, () => ({ regionId, faction })),
+        },
+        score: amount,
+      });
+    }
+  }
+  return out;
+}
+
+/** Influence (1 English ↔ 2 non-English) and Dispute (1 Welsh ↔ 1 non-Welsh). */
+function factionSwapCandidates(
+  state: Tkid2State,
+  faction: Faction,
+  otherCount: number,
+  bordering: boolean,
+  ownCount = 1,
+): Candidate[] {
+  const others = FACTIONS.filter((f) => f !== faction);
+  const out: Candidate[] = [];
+  for (const a of REGION_IDS) {
+    if (!isOpen(state, a)) continue;
+    const have = state.regions[a].cubes[faction];
+    if (have === 0) continue;
+    const bList = bordering ? REGION_BY_ID[a].adjacent : REGION_IDS.filter((r) => r !== a);
+    for (const b of bList) {
+      if (!isOpen(state, b)) continue;
+      const full = Math.min(ownCount, have);
+      // Enumerate every (own m, other n) combination up to the full swap;
+      // the max-score filter keeps only the most complete ones.
+      for (let m = 1; m <= full; m++) {
+        for (let n = 1; n <= otherCount; n++) {
+          for (const set of factionMultisets(state.regions[b].cubes, n, others)) {
+            out.push({
+              params: {
+                from: { regionId: a, factions: Array.from({ length: m }, () => faction) },
+                to: { regionId: b, factions: set },
+              },
+              score: m === ownCount && n === otherCount ? 10 : m + n,
+            });
           }
         }
       }
+    }
+  }
+  return out;
+}
+
+/** Regions eligible for the Scottish/Welsh/English cunning removal cards. */
+function cunningTargets(state: Tkid2State, faction: Faction): RegionId[] {
+  return supportTargets(state, faction);
+}
+
+/** Quell / Muster: return one `faction` follower from an eligible region, then
+ *  place two followers from the supply into that region. */
+function returnAndPlaceCandidates(state: Tkid2State, faction: Faction): Candidate[] {
+  const targets = cunningTargets(state, faction);
+  if (targets.length === 0) return [];
+  const withFollower = targets.filter((r) => state.regions[r].cubes[faction] > 0);
+  const out: Candidate[] = [];
+  const placementsFor = (
+    regionId: RegionId,
+    extraSupply: FactionCounts,
+  ): Placement[][] => {
+    const supply: FactionCounts = { ...state.supply };
+    for (const f of FACTIONS) supply[f] += extraSupply[f];
+    const n = Math.min(2, totalCubes(supply));
+    if (n === 0) return [[]];
+    return factionMultisets(supply, n).map((set) =>
+      set.map((f) => ({ regionId, faction: f })),
+    );
+  };
+  if (withFollower.length > 0) {
+    for (const regionId of withFollower) {
+      const extra = zeroCounts();
+      extra[faction] = 1; // the returned follower is back in the supply
+      for (const placements of placementsFor(regionId, extra)) {
+        out.push({
+          params: { regionId, returnFactions: [faction], placements },
+          score: 8 + placements.length,
+        });
+      }
+    }
+    return out;
+  }
+  // Fallback: no such follower in any eligible region — just place two.
+  for (const regionId of targets) {
+    for (const placements of placementsFor(regionId, zeroCounts())) {
+      if (placements.length === 0) continue;
+      out.push({
+        params: { regionId, returnFactions: [], placements },
+        score: placements.length,
+      });
+    }
+  }
+  return out;
+}
+
+function suppressCandidates(state: Tkid2State): Candidate[] {
+  const targets = cunningTargets(state, "english");
+  if (targets.length === 0) return [];
+  const out: Candidate[] = [];
+  for (const regionId of targets) {
+    const cubes = state.regions[regionId].cubes;
+    const hasEnglish = cubes.english > 0;
+    // Choose the second returned follower from the region (after the English
+    // one has left) and the placed follower from the supply.
+    const afterEnglish: FactionCounts = { ...cubes };
+    if (hasEnglish) afterEnglish.english -= 1;
+    const seconds = hasEnglish
+      ? FACTIONS.filter((f) => afterEnglish[f] > 0)
+      : FACTIONS.filter((f) => cubes[f] > 0);
+    const returnedBase: Faction[] = hasEnglish ? ["english"] : [];
+    const options: Faction[][] =
+      seconds.length > 0
+        ? seconds.map((f) => [...returnedBase, f])
+        : returnedBase.length > 0
+          ? [returnedBase]
+          : [];
+    for (const returnFactions of options.length > 0 ? options : [[] as Faction[]]) {
+      const supply: FactionCounts = { ...state.supply };
+      for (const f of returnFactions) supply[f] += 1;
+      const placeable = FACTIONS.filter((f) => supply[f] > 0);
+      const score =
+        (returnFactions.includes("english") ? 8 : 0) +
+        (returnFactions.length > (hasEnglish ? 1 : 0) ? 4 : 0) +
+        (placeable.length > 0 ? 1 : 0);
+      if (placeable.length === 0) {
+        if (returnFactions.length > 0) {
+          out.push({ params: { regionId, returnFactions, placements: [] }, score });
+        }
+        continue;
+      }
+      for (const f of placeable) {
+        out.push({
+          params: {
+            regionId,
+            returnFactions,
+            placements: [{ regionId, faction: f }],
+          },
+          score,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function spyCandidates(state: Tkid2State, depth = 0): Candidate[] {
+  if (depth > 1) return [];
+  const me = state.currentPlayerIndex;
+  const out: Candidate[] = [];
+  state.players.forEach((p, idx) => {
+    if (idx === me || p.discard.length === 0) return;
+    const top = p.discard[p.discard.length - 1];
+    // A Spy on top of a Spy would recurse forever; skip those piles.
+    if (top === "spy") return;
+    const inner = cardCandidates(state, top, depth + 1);
+    if (inner.length === 0) {
+      out.push({ params: { spyPlayerId: p.id, spyParams: {} }, score: 1 });
+      return;
+    }
+    const best = Math.max(...inner.map((c) => c.score));
+    for (const c of inner) {
+      if (c.score !== best) continue;
+      out.push({
+        params: { spyPlayerId: p.id, spyParams: c.params },
+        score: 1,
+      });
+    }
+  });
+  return out;
+}
+
+function cardCandidates(state: Tkid2State, cardId: CardId, depth = 0): Candidate[] {
+  switch (cardId) {
+    case "scottish-support":
+      return supportCandidates(state, "scottish");
+    case "welsh-support":
+      return supportCandidates(state, "welsh");
+    case "english-support":
+      return supportCandidates(state, "english");
+    case "assemble-1":
+    case "assemble-2":
+      return assembleCandidates(state);
+    case "negotiate":
+      return negotiateCandidates(state);
+    case "manoeuvre":
+      return manoeuvreCandidates(state);
+    case "outmanoeuvre":
+      return outmanoeuvreCandidates(state);
+    case "spy":
+      return spyCandidates(state, depth);
+    case "ambush":
+      return ambushCandidates(state);
+    case "march":
+      return marchCandidates(state);
+    case "plot":
+      return []; // never playable
+    case "aid":
+      return aidCandidates(state);
+    case "influence":
+      return factionSwapCandidates(state, "english", 2, false);
+    case "dispute":
+      return factionSwapCandidates(state, "welsh", 1, false);
+    case "edict":
+      return factionSwapCandidates(state, "scottish", 2, true, 2);
+    case "resist": {
+      const targets = supportTargets(state, "scottish");
+      const pool = FACTIONS.filter((f) => f !== "scottish");
+      const n = Math.min(
+        2,
+        pool.reduce((a, f) => a + state.supply[f], 0),
+      );
+      if (n === 0) return [];
+      const out: Candidate[] = [];
+      for (const regionId of targets) {
+        for (const set of factionMultisets(state.supply, n, pool)) {
+          out.push({
+            params: {
+              regionId,
+              placements: set.map((f) => ({ regionId, faction: f })),
+            },
+            score: n,
+          });
+        }
+      }
+      return out;
+    }
+    case "quell":
+      return returnAndPlaceCandidates(state, "welsh");
+    case "muster":
+      return returnAndPlaceCandidates(state, "scottish");
+    case "suppress":
+      return suppressCandidates(state);
+    default:
+      return [];
+  }
+}
+
+/**
+ * All legal parameter assignments for playing `cardId` right now. An empty
+ * array means the card may only be played for no effect (empty params).
+ */
+export function enumerateCardParams(state: Tkid2State, cardId: CardId): CardParams[] {
+  if (cardId === "plot") return [];
+  const candidates = cardCandidates(state, cardId);
+  if (candidates.length === 0) return [];
+  const best = Math.max(...candidates.map((c) => c.score));
+  const seen = new Set<string>();
+  const out: CardParams[] = [];
+  for (const c of candidates) {
+    if (c.score !== best) continue;
+    const key = canonicalParams(cardId, c.params);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c.params);
+  }
+  return out;
+}
+
+// ===========================================================================
+// Legal actions
+// ===========================================================================
+
+export function legalActions(state: Tkid2State): Tkid2Action[] {
+  if (state.phase === "ended") return [];
+  if (state.pendingSummon) {
+    return summonOptions(state).map((o) => ({
+      type: "summon" as const,
+      regionId: o.regionId,
+      faction: o.faction,
+    }));
+  }
+  const player = currentPlayer(state);
+  const actions: Tkid2Action[] = [{ type: "pass" }];
+  for (const cardId of player.hand) {
+    if (cardId === "plot") continue;
+    const paramSets = enumerateCardParams(state, cardId);
+    if (paramSets.length === 0) {
+      actions.push({ type: "play", cardId, params: {} });
+    } else {
+      for (const params of paramSets) actions.push({ type: "play", cardId, params });
     }
   }
   return actions;
 }
 
 // ===========================================================================
-// Transition
+// Applying actions
 // ===========================================================================
 
-function clone(state: TKID2State): TKID2State {
-  return {
-    ...state,
-    players: state.players.map((p) => ({
-      ...p,
-      hand: [...p.hand],
-      court: { ...p.court },
-    })),
-    regions: Object.fromEntries(
-      Object.entries(state.regions).map(([k, v]) => [k, { ...v }]),
-    ) as Record<RegionId, Record<Faction, number>>,
-    eventOrder: [...state.eventOrder],
-    crowns: { ...state.crowns },
-  };
+function clone(state: Tkid2State): Tkid2State {
+  return JSON.parse(JSON.stringify(state)) as Tkid2State;
 }
 
-function reject(state: TKID2State, error: string): ApplyResult {
+function reject(state: Tkid2State, error: string): ApplyResult {
   return { state, events: [], error };
 }
 
-/**
- * Apply a single action for the current player. Returns a new state plus the
- * events emitted (including any automatic region resolution when the last
- * player passes and the follow-on game end).
- */
-export function applyAction(state: TKID2State, action: TKID2Action): ApplyResult {
-  if (state.phase === "ended") return reject(state, "Game already ended");
-  const region = currentRegionId(state);
-  if (region === null) return reject(state, "No region is being contested");
-  const player = currentPlayer(state);
-  if (player.passed) return reject(state, "Current player has already passed");
-
-  const next = clone(state);
-  const events: TKID2Event[] = [];
-  const np = next.players[next.currentPlayerIndex];
-  const cubes = next.regions[region];
-
-  if (action.type === "pass") {
-    let took: Faction | null = null;
-    if (action.takeFollower) {
-      if (cubes[action.takeFollower] <= 0) {
-        return reject(state, "No such follower to take in this region");
+/** Mutates `state`: performs the board effect of `cardId` with `params`. */
+function resolveCardEffect(state: Tkid2State, cardId: CardId, params: CardParams): void {
+  switch (cardId) {
+    case "scottish-support":
+    case "welsh-support":
+    case "english-support":
+    case "assemble-1":
+    case "assemble-2":
+    case "aid":
+    case "resist": {
+      for (const pl of params.placements ?? []) {
+        if (state.supply[pl.faction] > 0) {
+          state.supply[pl.faction] -= 1;
+          state.regions[pl.regionId].cubes[pl.faction] += 1;
+        }
       }
-      cubes[action.takeFollower] -= 1;
-      np.court[action.takeFollower] += 1;
-      took = action.takeFollower;
+      break;
     }
-    np.passed = true;
-    events.push({ kind: "passed", playerId: np.id, tookFollower: took });
-  } else {
-    const card = cardById(action.cardId);
-    if (!card) return reject(state, "Unknown card");
-    if (!np.hand.includes(action.cardId)) {
-      return reject(state, "Card is not in hand");
+    case "negotiate": {
+      if (params.slotA === undefined || params.slotB === undefined) break;
+      const a = state.slots.find((s) => s.position === params.slotA);
+      const b = state.slots.find((s) => s.position === params.slotB);
+      if (!a || !b) break;
+      const tmp = a.regionId;
+      a.regionId = b.regionId;
+      b.regionId = tmp;
+      // The negotiation disc travels with the chosen card.
+      const target = [a, b].find((s) => s.regionId === params.discRegionId);
+      if (target) target.negotiationDisc = true;
+      break;
     }
-
-    if (card.kind === "muster") {
-      cubes[card.faction as Faction] += MUSTER_AMOUNT;
-    } else if (card.kind === "exile") {
-      const f = card.faction as Faction;
-      if (cubes[f] <= 0) return reject(state, "No cubes of that faction to exile");
-      cubes[f] = Math.max(0, cubes[f] - EXILE_AMOUNT);
-    } else {
-      // manoeuvre
-      const { fromRegion, faction } = action;
-      if (!fromRegion || !faction) {
-        return reject(state, "Manoeuvre requires a source region and faction");
+    case "manoeuvre":
+    case "outmanoeuvre":
+    case "influence":
+    case "dispute":
+    case "edict": {
+      const { from, to } = params;
+      if (!from || !to) break;
+      for (const f of from.factions) {
+        state.regions[from.regionId].cubes[f] -= 1;
+        state.regions[to.regionId].cubes[f] += 1;
       }
-      const def = REGION_BY_ID[region];
-      if (!def.adjacent.includes(fromRegion)) {
-        return reject(state, "Source region is not adjacent");
+      for (const f of to.factions) {
+        state.regions[to.regionId].cubes[f] -= 1;
+        state.regions[from.regionId].cubes[f] += 1;
       }
-      const src = next.regions[fromRegion];
-      if (src[faction] <= 0) {
-        return reject(state, "No cubes of that faction to manoeuvre");
+      if (cardId === "manoeuvre" || cardId === "outmanoeuvre") {
+        state.lastSwap = {
+          kind: cardId,
+          playerIndex: state.currentPlayerIndex,
+          seq: state.actionSeq + 1,
+          from: { regionId: from.regionId, factions: canonFactions(from.factions) },
+          to: { regionId: to.regionId, factions: canonFactions(to.factions) },
+        };
       }
-      const moved = Math.min(MANOEUVRE_AMOUNT, src[faction]);
-      src[faction] -= moved;
-      cubes[faction] += moved;
+      break;
     }
-
-    // Remove the played card from hand (single-use).
-    np.hand = np.hand.filter((id) => id !== action.cardId);
-    events.push({ kind: "cardPlayed", playerId: np.id, cardId: action.cardId, region });
+    case "march": {
+      const { from, to } = params;
+      if (!from || !to) break;
+      for (const f of from.factions) {
+        state.regions[from.regionId].cubes[f] -= 1;
+        state.regions[to.regionId].cubes[f] += 1;
+      }
+      break;
+    }
+    case "ambush": {
+      for (const pl of params.placements ?? []) {
+        if (state.supply[pl.faction] > 0) {
+          state.supply[pl.faction] -= 1;
+          state.regions[pl.regionId].cubes[pl.faction] += 1;
+        }
+      }
+      for (const f of params.returnFactions ?? []) {
+        if (params.regionId && state.regions[params.regionId].cubes[f] > 0) {
+          state.regions[params.regionId].cubes[f] -= 1;
+          state.supply[f] += 1;
+        }
+      }
+      break;
+    }
+    case "quell":
+    case "muster":
+    case "suppress": {
+      const regionId = params.regionId;
+      if (!regionId) break;
+      for (const f of params.returnFactions ?? []) {
+        if (state.regions[regionId].cubes[f] > 0) {
+          state.regions[regionId].cubes[f] -= 1;
+          state.supply[f] += 1;
+        }
+      }
+      for (const pl of params.placements ?? []) {
+        if (state.supply[pl.faction] > 0) {
+          state.supply[pl.faction] -= 1;
+          state.regions[pl.regionId].cubes[pl.faction] += 1;
+        }
+      }
+      break;
+    }
+    case "spy":
+      // Handled by the caller (needs the target's top discard).
+      break;
+    case "plot":
+      break;
   }
-
-  advanceTurn(next, events);
-  return { state: next, events };
 }
 
-/**
- * Advance to the next active player. If everyone has passed, resolve the
- * contested region and set up the next one (or end the game).
- */
-function advanceTurn(state: TKID2State, events: TKID2Event[]): void {
-  const n = state.players.length;
+function resolvePowerStruggle(state: Tkid2State, events: Tkid2Event[]): void {
+  const slot = state.slots.find((s) => s.faceUp);
+  if (!slot) return;
+  const regionId = slot.regionId;
+  const region = state.regions[regionId];
+  const cubes: FactionCounts = { ...region.cubes };
+  const winner = majorityFaction(cubes);
 
-  // Find the next player who has not passed.
-  let idx = state.currentPlayerIndex;
-  for (let step = 0; step < n; step++) {
-    idx = (idx + 1) % n;
-    if (!state.players[idx].passed) {
-      state.currentPlayerIndex = idx;
-      return;
+  if (winner) {
+    region.control = winner;
+  } else {
+    region.unstable = true;
+    state.instabilityInFrance -= 1;
+  }
+  // All followers in the region return to the supply.
+  for (const f of FACTIONS) {
+    state.supply[f] += region.cubes[f];
+    region.cubes[f] = 0;
+  }
+  slot.faceUp = false;
+
+  const record: StruggleRecord = {
+    regionId,
+    outcome: winner ?? "unstable",
+    cubes,
+  };
+  state.struggles.push(record);
+  events.push({ kind: "struggle", record });
+
+  if (state.instabilityInFrance === 0) {
+    state.phase = "ended";
+    state.ending = "invasion";
+    events.push({ kind: "invasion" });
+    return;
+  }
+  if (state.slots.every((s) => !s.faceUp)) {
+    state.phase = "ended";
+    state.ending = "coronation";
+    events.push({ kind: "coronation" });
+  }
+}
+
+function advanceTurn(state: Tkid2State): void {
+  state.currentPlayerIndex =
+    (state.currentPlayerIndex + 1) % state.players.length;
+}
+
+export function applyAction(state: Tkid2State, action: Tkid2Action): ApplyResult {
+  if (state.phase === "ended") return reject(state, "The game has ended");
+
+  if (action.type === "summon") {
+    if (!state.pendingSummon) return reject(state, "No summon is pending");
+    const region = state.regions[action.regionId];
+    if (!region || region.cubes[action.faction] <= 0) {
+      return reject(state, "No such follower to summon");
+    }
+    const next = clone(state);
+    const player = next.players[next.currentPlayerIndex];
+    next.regions[action.regionId].cubes[action.faction] -= 1;
+    player.court[action.faction] += 1;
+    next.pendingSummon = false;
+    advanceTurn(next);
+    return {
+      state: next,
+      events: [
+        {
+          kind: "summoned",
+          playerId: player.id,
+          regionId: action.regionId,
+          faction: action.faction,
+        },
+      ],
+    };
+  }
+
+  if (state.pendingSummon) {
+    return reject(state, "You must summon a follower to your court first");
+  }
+
+  if (action.type === "pass") {
+    const next = clone(state);
+    const events: Tkid2Event[] = [
+      { kind: "passed", playerId: currentPlayer(next).id },
+    ];
+    next.consecutivePasses += 1;
+    advanceTurn(next);
+    if (next.consecutivePasses >= next.players.length) {
+      next.consecutivePasses = 0;
+      resolvePowerStruggle(next, events);
+    }
+    return { state: next, events };
+  }
+
+  // action.type === "play"
+  const player = currentPlayer(state);
+  if (!player.hand.includes(action.cardId)) {
+    return reject(state, "That card is not in your hand");
+  }
+  if (action.cardId === "plot") {
+    return reject(state, "Plot cannot be taken during the game");
+  }
+
+  // Validate params against the enumerated legal assignments.
+  const legal = enumerateCardParams(state, action.cardId);
+  if (legal.length === 0) {
+    const empty =
+      !action.params ||
+      Object.keys(action.params).length === 0 ||
+      canonicalParams(action.cardId, action.params) ===
+        canonicalParams(action.cardId, {});
+    if (!empty) return reject(state, "This card can only be played for no effect");
+  } else {
+    const key = canonicalParams(action.cardId, action.params);
+    if (!legal.some((p) => canonicalParams(action.cardId, p) === key)) {
+      return reject(state, "Illegal parameters for this card");
     }
   }
 
-  // Everyone passed → resolve the contested region.
-  const region = state.eventOrder[state.eventIndex];
-  const owner = projectedOwner(state.regions[region]);
-  state.crowns[region] = owner;
-  events.push({ kind: "regionResolved", region, owner });
+  const next = clone(state);
+  const events: Tkid2Event[] = [];
+  const np = next.players[next.currentPlayerIndex];
 
-  // Settle the region: its cubes leave the board.
-  state.regions[region] = { english: 0, scottish: 0, welsh: 0 };
-
-  state.eventIndex += 1;
-  if (state.eventIndex >= state.eventOrder.length) {
-    state.phase = "ended";
-    events.push({ kind: "gameEnded" });
-    return;
+  if (action.cardId === "spy" && action.params.spyPlayerId) {
+    const target = next.players.find((p) => p.id === action.params.spyPlayerId);
+    const top = target?.discard[target.discard.length - 1];
+    if (top) {
+      resolveCardEffect(next, top, action.params.spyParams ?? {});
+      events.push({ kind: "played", playerId: np.id, cardId: top, viaSpy: true });
+    }
+  } else {
+    resolveCardEffect(next, action.cardId, action.params);
   }
 
-  // Start the next round: reset pass flags, rotate the starting player.
-  for (const p of state.players) p.passed = false;
-  state.currentPlayerIndex = state.eventIndex % n;
+  np.hand = np.hand.filter((c) => c !== action.cardId);
+  np.discard.push(action.cardId);
+  next.actionSeq += 1;
+  np.lastActionSeq = next.actionSeq;
+  if (np.hand.filter((c) => c !== "plot").length === 0 && np.emptyHandSeq === null) {
+    // Plot is never playable, so a hand holding only Plot counts as played out.
+    np.emptyHandSeq = next.actionSeq;
+  }
+  next.consecutivePasses = 0;
+  events.unshift({ kind: "played", playerId: np.id, cardId: action.cardId });
+
+  // Summon a follower to court — mandatory, skipped only when impossible.
+  if (summonOptions(next).length > 0) {
+    next.pendingSummon = true;
+  } else {
+    events.push({ kind: "summonSkipped", playerId: np.id });
+    advanceTurn(next);
+  }
+  return { state: next, events };
 }
 
 // ===========================================================================
@@ -507,98 +1542,186 @@ function advanceTurn(state: TKID2State, events: TKID2Event[]): void {
 
 export interface FactionStanding {
   faction: Faction;
-  crowns: number;
+  regions: number;
+  /** Index in `struggles` of this faction's most recent win (-1 = never). */
+  lastWin: number;
 }
 
-/** How many crowns each native faction (and the foreign power) holds. */
-export function crownCounts(state: TKID2State): Record<CrownOwner, number> {
-  const counts: Record<CrownOwner, number> = {
-    english: 0,
-    scottish: 0,
-    welsh: 0,
-    french: 0,
+/** Factions ranked most → least powerful (regions, then most recent win). */
+export function factionStandings(state: Tkid2State): FactionStanding[] {
+  const counts = controlledCounts(state);
+  const lastWin = (f: Faction) => {
+    for (let i = state.struggles.length - 1; i >= 0; i--) {
+      if (state.struggles[i].outcome === f) return i;
+    }
+    return -1;
   };
-  for (const owner of Object.values(state.crowns)) counts[owner] += 1;
-  return counts;
-}
-
-export function isInvasion(state: TKID2State): boolean {
-  return crownCounts(state)[FOREIGN] >= INVASION_THRESHOLD;
-}
-
-/** Native factions ranked by crowns (desc); ties broken by fixed order. */
-export function factionStandings(state: TKID2State): FactionStanding[] {
-  const counts = crownCounts(state);
-  return FACTIONS.map((f) => ({ faction: f, crowns: counts[f] })).sort(
-    (a, b) => b.crowns - a.crowns || FACTIONS.indexOf(a.faction) - FACTIONS.indexOf(b.faction),
+  return FACTIONS.map((f) => ({ faction: f, regions: counts[f], lastWin: lastWin(f) })).sort(
+    (a, b) => b.regions - a.regions || b.lastWin - a.lastWin,
   );
 }
 
-/**
- * The faction whose follower alignment decides the game:
- *  - normal game → the strongest native faction
- *  - invasion    → the weakest native faction (loyal opposition)
- */
-export function decidingFaction(state: TKID2State): Faction {
-  const standings = factionStandings(state);
-  return isInvasion(state)
-    ? standings[standings.length - 1].faction
-    : standings[0].faction;
+export function hasPlot(player: Tkid2Player): boolean {
+  return player.hand.includes("plot");
+}
+
+/** Complete sets (one follower of each faction) in a court. */
+export function setCount(court: FactionCounts): number {
+  return Math.min(court.scottish, court.welsh, court.english);
+}
+
+/** Sets counting an unplayed Plot card as one follower of the best faction. */
+export function setCountWithPlot(court: FactionCounts, plot: boolean): number {
+  if (!plot) return setCount(court);
+  let best = setCount(court);
+  for (const f of FACTIONS) {
+    const c = { ...court };
+    c[f] += 1;
+    best = Math.max(best, setCount(c));
+  }
+  return best;
 }
 
 export interface PlayerResult {
   playerId: PlayerId;
   name: string;
-  /** Followers of the deciding faction — the primary score. */
+  /** Invasion: complete sets. Coronation: followers of the strongest faction. */
   score: number;
-  /** Full ranked tiebreak vector (deciding faction first, then descending). */
-  tiebreak: number[];
+  /** Coronation only: followers of the second faction (tiebreak). */
+  secondary: number;
+  winner: boolean;
+  plot: boolean;
 }
 
-/**
- * Final results, best first. Primary score is followers of the deciding
- * faction. Ties are broken by followers of the remaining factions in
- * (normal: descending crowns) / (invasion: ascending crowns) order.
- */
-export function results(state: TKID2State): PlayerResult[] {
+export interface GameResult {
+  ending: Ending;
+  standings: FactionStanding[];
+  results: PlayerResult[];
+  winnerIds: PlayerId[];
+  /** In a four-player game, teammates share victory. */
+  teams: boolean;
+}
+
+function teammateIndex(state: Tkid2State, idx: number): number | null {
+  return state.players.length === 4 ? (idx + 2) % 4 : null;
+}
+
+export function gameResult(state: Tkid2State): GameResult | null {
+  if (state.phase !== "ended" || !state.ending) return null;
   const standings = factionStandings(state);
-  const invasion = isInvasion(state);
-  // Order in which faction alignments matter for tiebreaks.
-  const order = invasion
-    ? [...standings].reverse().map((s) => s.faction)
-    : standings.map((s) => s.faction);
+  const teams = state.players.length === 4;
 
-  const rows = state.players.map((p) => ({
-    playerId: p.id,
-    name: p.name,
-    score: p.court[order[0]],
-    tiebreak: order.map((f) => p.court[f]),
-  }));
-
-  rows.sort((a, b) => {
-    for (let i = 0; i < a.tiebreak.length; i++) {
-      if (b.tiebreak[i] !== a.tiebreak[i]) return b.tiebreak[i] - a.tiebreak[i];
+  if (state.ending === "invasion") {
+    // Winner: most complete sets of followers (teams combine their courts).
+    const rows: PlayerResult[] = state.players.map((p, i) => {
+      const mateIdx = teammateIndex(state, i);
+      const court: FactionCounts = { ...p.court };
+      let plot = hasPlot(p);
+      if (mateIdx !== null) {
+        const mate = state.players[mateIdx];
+        for (const f of FACTIONS) court[f] += mate.court[f];
+        plot = plot || hasPlot(mate);
+      }
+      return {
+        playerId: p.id,
+        name: p.name,
+        score: setCountWithPlot(court, plot),
+        secondary: 0,
+        winner: false,
+        plot: hasPlot(p),
+      };
+    });
+    const bestSets = Math.max(...rows.map((r) => r.score));
+    let tied = state.players
+      .map((_, i) => i)
+      .filter((i) => rows[i].score === bestSets);
+    if (tied.length > 1) {
+      // Tiebreak: whoever (whose team) most recently played an action card.
+      const recency = (i: number) => {
+        const mateIdx = teammateIndex(state, i);
+        return Math.max(
+          state.players[i].lastActionSeq,
+          mateIdx !== null ? state.players[mateIdx].lastActionSeq : -1,
+        );
+      };
+      const bestRecency = Math.max(...tied.map(recency));
+      tied = tied.filter((i) => recency(i) === bestRecency);
     }
-    return 0;
+    const winnerSet = new Set<number>(tied);
+    if (teams) {
+      for (const i of Array.from(winnerSet)) {
+        const mateIdx = teammateIndex(state, i);
+        if (mateIdx !== null) winnerSet.add(mateIdx);
+      }
+    }
+    winnerSet.forEach((i) => (rows[i].winner = true));
+    return {
+      ending: "invasion",
+      standings,
+      results: rows,
+      winnerIds: Array.from(winnerSet).map((i) => state.players[i].id),
+      teams,
+    };
+  }
+
+  // Coronation: most followers of the most powerful faction in court.
+  const [first, second] = [standings[0].faction, standings[1].faction];
+  const rows: PlayerResult[] = state.players.map((p) => {
+    // An unplayed Plot counts as one follower of a faction of the holder's
+    // choice — the engine assumes the optimal choice (the strongest faction,
+    // falling back to the runner-up when that breaks a tie better).
+    let score = p.court[first];
+    let secondary = p.court[second];
+    if (hasPlot(p)) score += 1;
+    return {
+      playerId: p.id,
+      name: p.name,
+      score,
+      secondary,
+      winner: false,
+      plot: hasPlot(p),
+    };
   });
-  return rows;
-}
-
-export function isGameOver(state: TKID2State): boolean {
-  return state.phase === "ended";
-}
-
-/** Winner(s) of a finished game (multiple only on a perfect tie). */
-export function winners(state: TKID2State): PlayerResult[] {
-  if (!isGameOver(state)) return [];
-  const ranked = results(state);
-  if (ranked.length === 0) return [];
-  const best = ranked[0];
-  return ranked.filter(
-    (r) => r.tiebreak.every((v, i) => v === best.tiebreak[i]),
-  );
-}
-
-function cap(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1);
+  const bestScore = Math.max(...rows.map((r) => r.score));
+  let tied = rows.map((_, i) => i).filter((i) => rows[i].score === bestScore);
+  if (tied.length > 1) {
+    const bestSecondary = Math.max(...tied.map((i) => rows[i].secondary));
+    tied = tied.filter((i) => rows[i].secondary === bestSecondary);
+  }
+  if (tied.length > 1) {
+    // Plot supersedes the normal tiebreaker when tied among the top factions.
+    const plotters = tied.filter((i) => hasPlot(state.players[i]));
+    if (plotters.length >= 1 && plotters.length < tied.length) tied = plotters;
+  }
+  if (tied.length > 1) {
+    // Player (or team) who first played all their action cards wins.
+    const emptySeq = (i: number) => {
+      const own = state.players[i].emptyHandSeq;
+      if (!teams) return own ?? Number.POSITIVE_INFINITY;
+      const mateIdx = teammateIndex(state, i)!;
+      const mate = state.players[mateIdx].emptyHandSeq;
+      return own === null || mate === null
+        ? Number.POSITIVE_INFINITY
+        : Math.max(own, mate);
+    };
+    const best = Math.min(...tied.map(emptySeq));
+    if (best !== Number.POSITIVE_INFINITY) {
+      tied = tied.filter((i) => emptySeq(i) === best);
+    }
+  }
+  const winnerSet = new Set<number>(tied);
+  if (teams) {
+    for (const i of Array.from(winnerSet)) {
+      const mateIdx = teammateIndex(state, i);
+      if (mateIdx !== null) winnerSet.add(mateIdx);
+    }
+  }
+  winnerSet.forEach((i) => (rows[i].winner = true));
+  return {
+    ending: "coronation",
+    standings,
+    results: rows,
+    winnerIds: Array.from(winnerSet).map((i) => state.players[i].id),
+    teams,
+  };
 }

--- a/src/features/tkid2/selection.ts
+++ b/src/features/tkid2/selection.ts
@@ -1,0 +1,329 @@
+/**
+ * Multi-step target selection for playing an action card.
+ *
+ * The engine enumerates every legal parameter assignment for a card
+ * (`enumerateCardParams`). This module turns that list into a guided,
+ * click-by-click flow on the board: each pick (a region, a follower cube, a
+ * region-card slot, or a labelled variant) filters the remaining options
+ * until exactly one legal assignment is left, which is then dispatched.
+ * Because every candidate comes from the engine, only legal plays can ever
+ * be produced.
+ */
+import {
+  CARD_INFO,
+  CardId,
+  CardParams,
+  FACTION_LABEL,
+  Faction,
+  PlayerId,
+  RegionId,
+  regionName,
+} from "./engine/tkid2Engine";
+
+export interface CubeRef {
+  regionId: RegionId;
+  faction: Faction;
+}
+
+export function cubeKey(c: CubeRef): string {
+  return `${c.regionId}:${c.faction}`;
+}
+
+export interface Selection {
+  /** Card being played from hand (for Spy this stays "spy"). */
+  cardId: CardId;
+  /** Card whose effect is being resolved (Spy: the copied card). */
+  effectiveCardId: CardId;
+  spyPlayerId?: PlayerId;
+  /** Remaining legal parameter assignments (inner params for Spy). */
+  options: CardParams[];
+  regionsPicked: RegionId[];
+  cubesPicked: CubeRef[];
+  slotsPicked: number[];
+}
+
+export interface SelectionTargets {
+  prompt: string;
+  regions?: RegionId[];
+  cubes?: CubeRef[];
+  slots?: number[];
+  variants?: { label: string; params: CardParams }[];
+  /** Set when the selection is complete: dispatch these params. */
+  done?: CardParams;
+}
+
+const REGION_FIRST: CardId[] = [
+  "scottish-support",
+  "welsh-support",
+  "english-support",
+  "resist",
+  "aid",
+  "ambush",
+  "quell",
+  "muster",
+  "suppress",
+];
+
+const CUBE_SWAP: CardId[] = [
+  "manoeuvre",
+  "outmanoeuvre",
+  "march",
+  "influence",
+  "dispute",
+  "edict",
+];
+
+// ---------------------------------------------------------------------------
+// Multiset helpers over cube references
+// ---------------------------------------------------------------------------
+
+function optionCubes(cardId: CardId, p: CardParams): CubeRef[] {
+  const out: CubeRef[] = [];
+  // March moves cubes out of one region; only the source side is clickable.
+  const sides = cardId === "march" ? [p.from] : [p.from, p.to];
+  for (const side of sides) {
+    if (!side) continue;
+    for (const f of side.factions) out.push({ regionId: side.regionId, faction: f });
+  }
+  return out;
+}
+
+function counted(cubes: CubeRef[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const c of cubes) m.set(cubeKey(c), (m.get(cubeKey(c)) ?? 0) + 1);
+  return m;
+}
+
+/** picks ⊆ option cubes (as multisets). */
+function isCompatible(cardId: CardId, option: CardParams, picks: CubeRef[]): boolean {
+  const have = counted(optionCubes(cardId, option));
+  const want = counted(picks);
+  for (const [k, n] of Array.from(want.entries())) {
+    if ((have.get(k) ?? 0) < n) return false;
+  }
+  return true;
+}
+
+/** Distinct cubes that could be the next pick for any compatible option. */
+function remainderCubes(cardId: CardId, options: CardParams[], picks: CubeRef[]): CubeRef[] {
+  const seen = new Set<string>();
+  const out: CubeRef[] = [];
+  const want = counted(picks);
+  for (const o of options) {
+    const have = counted(optionCubes(cardId, o));
+    for (const [k, n] of Array.from(have.entries())) {
+      if (n > (want.get(k) ?? 0) && !seen.has(k)) {
+        seen.add(k);
+        const [regionId, faction] = k.split(":") as [RegionId, Faction];
+        out.push({ regionId, faction });
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+function factionList(fs: Faction[]): string {
+  return fs.map((f) => FACTION_LABEL[f]).join(" + ");
+}
+
+/** Human-readable label for a fully specified variant. */
+export function describeVariant(cardId: CardId, p: CardParams): string {
+  const parts: string[] = [];
+  if (p.returnFactions && p.returnFactions.length > 0) {
+    parts.push(`Return ${factionList(p.returnFactions)}`);
+  }
+  if (p.placements && p.placements.length > 0) {
+    parts.push(`Place ${factionList(p.placements.map((pl) => pl.faction))}`);
+  }
+  if (p.discRegionId) {
+    parts.push(`Disc on ${regionName(p.discRegionId)}`);
+  }
+  if (parts.length === 0 && p.faction) parts.push(FACTION_LABEL[p.faction]);
+  return parts.length > 0 ? parts.join(" · ") : "Resolve";
+}
+
+// ---------------------------------------------------------------------------
+// The selection state machine
+// ---------------------------------------------------------------------------
+
+export function startSelection(
+  cardId: CardId,
+  options: CardParams[],
+  spy?: { playerId: PlayerId; effectiveCardId: CardId },
+): Selection {
+  return {
+    cardId,
+    effectiveCardId: spy ? spy.effectiveCardId : cardId,
+    spyPlayerId: spy?.playerId,
+    options,
+    regionsPicked: [],
+    cubesPicked: [],
+    slotsPicked: [],
+  };
+}
+
+/** Wraps inner params back into Spy params when needed. */
+export function finalParams(sel: Selection, inner: CardParams): CardParams {
+  if (sel.cardId === "spy" && sel.spyPlayerId) {
+    return { spyPlayerId: sel.spyPlayerId, spyParams: inner };
+  }
+  return inner;
+}
+
+export function getTargets(sel: Selection): SelectionTargets {
+  const card = CARD_INFO[sel.effectiveCardId];
+  const id = sel.effectiveCardId;
+
+  // A single remaining assignment is fully determined — dispatch it.
+  if (sel.options.length === 1) {
+    return { prompt: card.name, done: sel.options[0] };
+  }
+
+  if (id === "assemble-1" || id === "assemble-2") {
+    const i = sel.regionsPicked.length;
+    const faction = sel.options[0]?.placements?.[i]?.faction;
+    if (faction) {
+      const regions = distinct(sel.options.map((o) => o.placements![i].regionId));
+      return {
+        prompt: `Assemble — place the ${FACTION_LABEL[faction]} follower. Choose a region.`,
+        regions,
+      };
+    }
+    return { prompt: card.name, done: sel.options[0] };
+  }
+
+  if (REGION_FIRST.includes(id)) {
+    if (sel.regionsPicked.length === 0) {
+      const regions = distinct(
+        sel.options.map((o) => o.regionId).filter((r): r is RegionId => !!r),
+      );
+      return { prompt: `${card.name} — choose a region.`, regions };
+    }
+    return {
+      prompt: `${card.name} — choose how to resolve it.`,
+      variants: sel.options.map((o) => ({ label: describeVariant(id, o), params: o })),
+    };
+  }
+
+  if (id === "negotiate") {
+    if (sel.slotsPicked.length < 2) {
+      const slots = distinct(
+        sel.options
+          .flatMap((o) => [o.slotA, o.slotB])
+          .filter((s): s is number => s !== undefined && !sel.slotsPicked.includes(s)),
+      );
+      return {
+        prompt:
+          sel.slotsPicked.length === 0
+            ? "Negotiate — choose the first region card to swap."
+            : "Negotiate — choose the second region card to swap.",
+        slots,
+      };
+    }
+    return {
+      prompt: "Negotiate — place your negotiation disc on one of the swapped cards.",
+      variants: sel.options.map((o) => ({
+        label: `Disc on ${regionName(o.discRegionId!)}`,
+        params: o,
+      })),
+    };
+  }
+
+  if (CUBE_SWAP.includes(id)) {
+    if (id === "march") {
+      const fromSize = sel.options[0]?.from?.factions.length ?? 0;
+      if (sel.cubesPicked.length >= fromSize) {
+        const regions = distinct(sel.options.map((o) => o.to!.regionId));
+        return {
+          prompt: "March — choose the bordering region to move them to.",
+          regions,
+        };
+      }
+    }
+    const cubes = remainderCubes(id, sel.options, sel.cubesPicked);
+    const prompts: Partial<Record<CardId, string[]>> = {
+      manoeuvre: [
+        "Manoeuvre — select the first follower to swap.",
+        "Manoeuvre — select the follower to swap it with (in another region).",
+      ],
+      outmanoeuvre: [
+        "Outmanoeuvre — select a follower to swap.",
+        "Outmanoeuvre — select the follower(s) in a bordering region to swap it with.",
+      ],
+      march: ["March — select the follower(s) to move (from one region)."],
+      influence: [
+        "Influence — select an English follower.",
+        "Influence — select the non-English follower(s) to swap it with.",
+      ],
+      dispute: [
+        "Dispute — select a Welsh follower.",
+        "Dispute — select the non-Welsh follower to swap it with.",
+      ],
+      edict: [
+        "Edict — select the Scottish follower(s).",
+        "Edict — select the non-Scottish follower(s) in a bordering region.",
+      ],
+    };
+    const stepPrompts = prompts[id] ?? ["Select a follower."];
+    const step = Math.min(sel.cubesPicked.length, stepPrompts.length - 1);
+    return { prompt: stepPrompts[step], cubes };
+  }
+
+  // Fallback: offer everything as labelled variants.
+  return {
+    prompt: `${card.name} — choose how to resolve it.`,
+    variants: sel.options.map((o) => ({ label: describeVariant(id, o), params: o })),
+  };
+}
+
+export function pickRegion(sel: Selection, regionId: RegionId): Selection {
+  const id = sel.effectiveCardId;
+  if (id === "assemble-1" || id === "assemble-2") {
+    const i = sel.regionsPicked.length;
+    const options = sel.options.filter((o) => o.placements?.[i]?.regionId === regionId);
+    if (options.length === 0) return sel;
+    return { ...sel, regionsPicked: [...sel.regionsPicked, regionId], options };
+  }
+  if (REGION_FIRST.includes(id)) {
+    const options = sel.options.filter((o) => o.regionId === regionId);
+    if (options.length === 0) return sel;
+    return { ...sel, regionsPicked: [...sel.regionsPicked, regionId], options };
+  }
+  if (id === "march") {
+    const options = sel.options.filter((o) => o.to!.regionId === regionId);
+    if (options.length === 0) return sel;
+    return { ...sel, regionsPicked: [...sel.regionsPicked, regionId], options };
+  }
+  return sel;
+}
+
+export function pickCube(sel: Selection, cube: CubeRef): Selection {
+  const id = sel.effectiveCardId;
+  if (!CUBE_SWAP.includes(id)) return sel;
+  const picks = [...sel.cubesPicked, cube];
+  const options = sel.options.filter((o) => isCompatible(id, o, picks));
+  if (options.length === 0) return sel; // illegal click — ignore
+  return { ...sel, cubesPicked: picks, options };
+}
+
+export function pickSlot(sel: Selection, position: number): Selection {
+  if (sel.effectiveCardId !== "negotiate") return sel;
+  const picks = [...sel.slotsPicked, position];
+  const options = sel.options.filter((o) =>
+    picks.every((p) => o.slotA === p || o.slotB === p),
+  );
+  if (options.length === 0) return sel;
+  return { ...sel, slotsPicked: picks, options };
+}
+
+export function pickVariant(sel: Selection, params: CardParams): Selection {
+  return { ...sel, options: [params] };
+}
+
+function distinct<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}

--- a/src/features/tkid2/style.ts
+++ b/src/features/tkid2/style.ts
@@ -1,0 +1,44 @@
+/**
+ * Visual constants for The King Is Dead, matching the second-edition
+ * rulebook's illuminated-manuscript look: aged parchment, portolan-chart
+ * map colours, and the three faction colours (Scottish blue, Welsh red,
+ * English yellow).
+ */
+import { Faction, RegionId } from "./engine/tkid2Engine";
+
+export const PARCHMENT = "#f0e3c0";
+export const PARCHMENT_DARK = "#e5d3a5";
+export const PARCHMENT_DEEP = "#d9c48e";
+export const INK = "#3a2c1a";
+export const INK_FADED = "#6b573a";
+export const RUBRIC = "#a32c26"; // the red used for headings in the book
+export const AZURE = "#2f4d8a"; // the blue of the cover shield
+export const GOLD = "#c8a244";
+export const CARD_BACK = "#7e2f26";
+export const SEA = "#e9dcb4";
+
+export const FACTION_COLOR: Record<Faction, { main: string; dark: string; light: string }> = {
+  scottish: { main: "#3d6cb0", dark: "#25457a", light: "#6f97cf" },
+  welsh: { main: "#bf3b2b", dark: "#84251a", light: "#d96a55" },
+  english: { main: "#e0af2e", dark: "#a37a14", light: "#efcb69" },
+};
+
+export const REGION_COLOR: Record<RegionId, { fill: string; edge: string }> = {
+  moray: { fill: "#8db3d6", edge: "#4a6f96" },
+  strathclyde: { fill: "#d3aa4b", edge: "#96742a" },
+  lancaster: { fill: "#79ab8f", edge: "#47755c" },
+  northumbria: { fill: "#dfa8b4", edge: "#a56b78" },
+  gwynedd: { fill: "#b05446", edge: "#7a3229" },
+  warwick: { fill: "#cd7f45", edge: "#95562a" },
+  essex: { fill: "#b9c465", edge: "#7f8a3c" },
+  devon: { fill: "#8caf5b", edge: "#5d7c37" },
+};
+
+export const FRANCE_COLOR = { fill: "#9aa5b5", edge: "#5e6a7d" };
+
+export const INSTABILITY = "#4a3524";
+export const NEGOTIATION = "#f6efe2";
+
+/** Font stacks — loaded via @import in index.css, with graceful fallbacks. */
+export const FONT_UNCIAL = "'Uncial Antiqua', 'Luminari', 'Palatino', serif";
+export const FONT_BODY = "'IM Fell English', 'Iowan Old Style', 'Palatino', Georgia, serif";

--- a/src/features/tkid2/useTkid2BotDriver.ts
+++ b/src/features/tkid2/useTkid2BotDriver.ts
@@ -1,36 +1,32 @@
 /**
- * Drives NPC turns for a locally-run TKID2 game.
+ * Drives NPC turns for a locally-run game of The King Is Dead.
  *
- * When it is a bot's turn (and the game is not over), the hook waits a short,
- * randomised "think" delay and then calls `onAction` with the bot's chosen
- * action. It guards against stale dispatches when the state changes or the
- * component unmounts mid-think.
- *
- * The hook is intentionally state-agnostic: it works with local React state
- * today and would work unchanged against a relayed online state tomorrow — the
- * caller just supplies the current state, the set of bot ids and how to apply
- * an action.
+ * When it is a bot's turn (including a pending summon after its card play)
+ * and the game is not over, the hook waits a short, randomised "think" delay
+ * and then calls `onAction` with the bot's chosen action. It guards against
+ * stale dispatches when the state changes or the component unmounts
+ * mid-think.
  */
 import { useEffect, useRef } from "react";
 import { Difficulty, chooseAction } from "./ai/botPolicy";
 import {
-  TKID2Action,
-  TKID2State,
+  Tkid2Action,
+  Tkid2State,
   currentPlayer,
   isGameOver,
 } from "./engine/tkid2Engine";
 
-const MIN_DELAY_MS = 700;
-const MAX_DELAY_MS = 1300;
+const MIN_DELAY_MS = 650;
+const MAX_DELAY_MS = 1250;
 
 export interface UseTkid2BotDriverArgs {
-  state: TKID2State | null;
+  state: Tkid2State | null;
   /** Player ids that are bots. */
   botIds: string[];
   /** Difficulty per bot id (falls back to "normal"). */
   difficultyById?: Record<string, Difficulty>;
   /** Apply the chosen action to the game. */
-  onAction: (action: TKID2Action) => void;
+  onAction: (action: Tkid2Action) => void;
   /** When false, the driver is paused (e.g. a modal is open). */
   enabled?: boolean;
 }
@@ -53,8 +49,10 @@ export function useTkid2BotDriver({
 
     let cancelled = false;
     const difficulty = difficultyById?.[player.id] ?? "normal";
-    const delay =
-      MIN_DELAY_MS + Math.random() * (MAX_DELAY_MS - MIN_DELAY_MS);
+    // Summons follow a card play; keep them snappy so a bot turn reads as
+    // one motion.
+    const base = state.pendingSummon ? 350 : MIN_DELAY_MS;
+    const delay = base + Math.random() * (MAX_DELAY_MS - MIN_DELAY_MS) * (state.pendingSummon ? 0.4 : 1);
 
     const timer = setTimeout(() => {
       if (cancelled) return;
@@ -66,9 +64,7 @@ export function useTkid2BotDriver({
       cancelled = true;
       clearTimeout(timer);
     };
-    // Re-run whenever the turn owner or the game shape changes. `botIds` should
-    // be referentially stable across renders (callers memoize it, e.g. with
-    // useMemo) so this effect does not re-fire spuriously.
+    // `botIds` and `difficultyById` are memoized by callers.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, botIds, enabled]);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+/* Medieval faces for "The King Is Dead" (fall back to system serifs offline) */
+@import url('https://fonts.googleapis.com/css2?family=Uncial+Antiqua&family=IM+Fell+English:ital@0;1&display=swap');
+
 html, body {
   height: 100%;
   margin: 0;


### PR DESCRIPTION
Replace the interpreted TKID2 engine and UI with a faithful implementation
of The King Is Dead: Second Edition (Peer Sylvester, Osprey Games):

Engine (features/tkid2/engine/tkid2Engine.ts):
- Real board: Moray, Strathclyde, Lancaster, Northumbria, Gwynedd,
  Warwick, Essex, Devon with the printed adjacency, plus France.
- Proper setup: 18 followers per faction (16 at 2P), home regions,
  random courts, 4 followers per region, shuffled region cards on
  numbered spaces 1-8, seeded and deterministic.
- The eight real action cards (3x Support, 2x Assemble, Negotiate,
  Manoeuvre, Outmanoeuvre) and all 12 cunning action cards for the
  advanced game (Spy, Ambush, March, Plot, Aid, Influence, Dispute,
  Edict, Resist, Quell, Suppress, Muster), including partial-action
  "resolve as far as possible" rules and the no-undo swap restriction.
- Mandatory follower summoning after every action, pass-around power
  struggles at the lowest face-up region card, control/instability
  discs, French invasion on the third disc, coronation scoring with
  the printed tiebreakers, and the four-player team variant.
- enumerateCardParams produces every legal parameter assignment,
  shared by validation, the UI and the AI.

UI (Tkid2Game, BoardMap, RegionCardTrack, ActionCardView, selection):
- Interactive SVG map of Britain in the rulebook's parchment/portolan
  style with follower cubes, control, instability and negotiation
  discs, the supply and France all visualised.
- Region-card track with numbered spaces, face-down cards and
  negotiation discs; contested region marked.
- Hand rendered as illustrated action cards with effect pictograms and
  rules text; cunning cards carry their printed marks.
- Guided click-by-click targeting driven by the engine's legal-move
  enumeration; Spy target picker; no-effect confirmations; chronicle
  log; victory panel with faction power ranking.
- New heraldic shield logo and Uncial/IM Fell typography per the book.

AI (features/tkid2/ai/botPolicy.ts): one-ply heuristic over the full
action space (court alignment weighted by projected faction power,
set collection under invasion risk) at easy/normal/godlike.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0166xtknHYRAXfANrHj3yfbb