### PR TITLE
TKID: accurate board map, human-like AI, and AI turn overlay

### DIFF
--- a/src/features/tkid2/BoardMap.tsx
+++ b/src/features/tkid2/BoardMap.tsx
@@ -21,55 +21,147 @@ import {
   SEA,
 } from "./style";
 
-/** Hand-tuned geometry for the stylised portolan chart of Britain. */
+type Pt = [number, number];
+
+/** Closed polygon → path (straight edges; shared vertices keep borders tight). */
+function polyPath(pts: Pt[]): string {
+  return `M ${pts.map(([x, y]) => `${x} ${y}`).join(" L ")} Z`;
+}
+
+/** Closed polygon → smoothed path (quadratic through edge midpoints). */
+function smoothClosed(pts: Pt[]): string {
+  const n = pts.length;
+  const mid = (a: Pt, b: Pt): Pt => [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+  const m0 = mid(pts[n - 1], pts[0]);
+  let d = `M ${m0[0]} ${m0[1]}`;
+  for (let i = 0; i < n; i++) {
+    const p = pts[i];
+    const m = mid(p, pts[(i + 1) % n]);
+    d += ` Q ${p[0]} ${p[1]} ${m[0]} ${m[1]}`;
+  }
+  return d + " Z";
+}
+
+/**
+ * The coastline of Britain, traced clockwise from the northern tip after the
+ * game board's map (ragged sea lochs in the north-west, the Solway and
+ * Humber inlets, the East Anglian bulge, Kent, the Cornish peninsula, the
+ * Bristol Channel and the Welsh coast).
+ */
+const ISLAND: Pt[] = [
+  [322, 42], [352, 60], [346, 88], [324, 98], [352, 112], [372, 140],
+  [388, 168], [380, 198], [354, 210], [336, 216], [368, 232], [398, 252],
+  [418, 288], [438, 330], [448, 372], [444, 408], [462, 428], [452, 448],
+  [492, 462], [524, 486], [532, 516], [516, 540], [498, 552], [536, 576],
+  [548, 600], [524, 622], [476, 634], [430, 642], [386, 650], [344, 658],
+  [306, 668], [270, 676], [240, 690], [200, 706], [162, 724], [148, 712],
+  [176, 692], [208, 672], [232, 654], [246, 636], [226, 624], [196, 630],
+  [166, 644], [154, 626], [176, 608], [192, 588], [182, 560], [162, 544],
+  [148, 528], [172, 516], [196, 512], [216, 496], [236, 480], [232, 456],
+  [218, 440], [238, 420], [234, 392], [222, 376], [246, 360], [226, 348],
+  [204, 352], [188, 336], [212, 322], [232, 312], [222, 288], [206, 292],
+  [198, 276], [222, 262], [216, 236], [192, 244], [186, 222], [208, 214],
+  [198, 188], [178, 196], [172, 176], [196, 168], [188, 142], [210, 136],
+  [204, 108], [228, 104], [224, 76], [252, 74], [262, 50], [290, 52],
+  [302, 36],
+];
+
+/** The Hebrides, off the north-west coast (part of Moray). */
+const ISLES: Pt[][] = [
+  [[140, 92], [160, 80], [170, 98], [156, 120], [138, 112]],
+  [[150, 150], [168, 136], [178, 152], [166, 178], [148, 172]],
+  [[128, 196], [146, 188], [152, 206], [138, 222], [124, 214]],
+];
+
+/**
+ * Region territories, tiling the island (edges beyond the coast are clipped
+ * away by the island silhouette, so only the shared inland borders matter).
+ * Shared border vertices are identical between neighbours.
+ */
 const SHAPES: Record<
   RegionId,
-  { path: string; label: [number, number]; cubes: [number, number] }
+  { poly: Pt[]; label: Pt; angle?: number; cubes: Pt }
 > = {
   moray: {
-    path: "M 210 42 C 255 24 330 20 388 32 C 436 42 456 78 452 118 C 449 146 431 158 400 161 L 205 170 C 172 170 152 142 158 110 C 163 80 182 53 210 42 Z",
-    label: [300, 78],
-    cubes: [298, 122],
+    poly: [
+      [95, 25], [330, 15], [430, 60], [415, 186], [330, 212], [250, 240],
+      [185, 258], [95, 180],
+    ],
+    label: [295, 112],
+    cubes: [290, 162],
   },
   strathclyde: {
-    path: "M 205 170 L 400 161 C 428 160 441 180 437 204 C 434 227 417 240 392 242 L 190 254 C 160 255 144 233 149 208 C 153 187 176 171 205 170 Z",
-    label: [293, 196],
-    cubes: [293, 226],
+    poly: [
+      [185, 258], [250, 240], [330, 212], [415, 186], [445, 210], [430, 262],
+      [330, 315], [290, 336], [200, 380], [160, 330],
+    ],
+    label: [302, 262],
+    angle: -12,
+    cubes: [300, 297],
   },
   lancaster: {
-    path: "M 190 254 L 297 249 L 302 428 L 178 435 C 153 435 141 413 145 388 L 152 292 C 154 270 168 256 190 254 Z",
-    label: [228, 283],
-    cubes: [226, 338],
+    poly: [
+      [200, 380], [290, 336], [330, 315], [342, 396], [356, 462], [306, 486],
+      [240, 476], [200, 474],
+    ],
+    label: [270, 382],
+    angle: -62,
+    cubes: [285, 430],
   },
   northumbria: {
-    path: "M 297 249 L 392 242 C 420 240 444 254 449 280 L 466 388 C 470 413 456 427 432 428 L 302 428 Z",
-    label: [374, 283],
-    cubes: [376, 340],
+    poly: [
+      [330, 315], [430, 262], [470, 300], [492, 432], [448, 460], [408, 492],
+      [356, 462], [342, 396],
+    ],
+    label: [404, 350],
+    angle: -62,
+    cubes: [398, 398],
   },
   gwynedd: {
-    path: "M 178 435 L 254 431 L 257 568 L 192 575 C 150 580 116 561 111 526 C 106 492 126 473 138 458 C 148 444 160 436 178 435 Z",
-    label: [184, 462],
-    cubes: [184, 512],
+    poly: [
+      [200, 474], [240, 476], [306, 486], [298, 530], [292, 572], [268, 606],
+      [240, 646], [130, 660], [120, 500],
+    ],
+    label: [196, 549],
+    angle: -68,
+    cubes: [240, 540],
   },
   warwick: {
-    path: "M 254 431 L 302 428 L 390 430 L 393 550 C 393 562 381 568 366 569 L 257 568 Z",
-    label: [322, 456],
-    cubes: [322, 505],
+    poly: [
+      [356, 462], [408, 492], [398, 538], [404, 584], [350, 582], [292, 572],
+      [298, 530], [306, 486],
+    ],
+    label: [352, 512],
+    angle: -8,
+    cubes: [352, 543],
   },
   essex: {
-    path: "M 390 430 L 432 428 C 456 427 468 434 471 454 L 486 540 C 490 566 476 582 452 586 L 394 592 C 392 578 393 562 393 550 L 390 430 Z",
-    label: [436, 466],
-    cubes: [432, 518],
+    poly: [
+      [408, 492], [448, 460], [492, 432], [560, 470], [580, 560], [560, 640],
+      [470, 680], [420, 660], [416, 620], [404, 584], [398, 538],
+    ],
+    label: [472, 508],
+    angle: -15,
+    cubes: [476, 550],
   },
   devon: {
-    path: "M 257 568 L 366 569 L 394 592 C 390 604 377 640 330 655 C 285 669 205 700 158 685 C 118 672 124 640 155 622 C 188 603 224 585 257 568 Z",
-    label: [268, 598],
-    cubes: [258, 634],
+    poly: [
+      [240, 646], [268, 606], [292, 572], [350, 582], [404, 584], [416, 620],
+      [420, 660], [380, 700], [240, 740], [120, 745], [125, 668],
+    ],
+    label: [246, 666],
+    angle: -14,
+    cubes: [322, 630],
   },
 };
 
-const FRANCE_PATH =
-  "M 476 648 C 528 630 598 634 634 654 L 640 786 L 470 786 C 452 748 456 694 476 648 Z";
+const FRANCE: Pt[] = [
+  [560, 656], [620, 636], [676, 668], [676, 796], [520, 796], [508, 744],
+  [532, 690],
+];
+
+const ISLAND_PATH = smoothClosed(ISLAND);
+const FRANCE_PATH = smoothClosed(FRANCE);
 
 const CUBE = 19;
 const CUBE_GAP = 23;
@@ -253,22 +345,35 @@ function InstabilityDisc({ x, y }: { x: number; y: number }) {
 }
 
 function RegionLabel({ regionId, contested }: { regionId: RegionId; contested: boolean }) {
-  const [x, y] = SHAPES[regionId].label;
+  const { label, angle } = SHAPES[regionId];
   const name = regionName(regionId);
   return (
-    <text
-      x={x}
-      y={y}
-      textAnchor="middle"
-      fontFamily={FONT_BODY}
-      fontSize={17}
-      fontWeight={700}
-      fill={INK}
-      style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 4, letterSpacing: 0.5 }}
-    >
-      <tspan fill={contested ? RUBRIC : RUBRIC}>{name.charAt(0)}</tspan>
-      <tspan>{name.slice(1)}</tspan>
-    </text>
+    <g transform={`translate(${label[0]}, ${label[1]}) rotate(${angle ?? 0})`}>
+      <text
+        textAnchor="middle"
+        fontFamily={FONT_BODY}
+        fontSize={17}
+        fontWeight={700}
+        fill={INK}
+        style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 4, letterSpacing: 0.5 }}
+      >
+        <tspan fill={RUBRIC}>{name.charAt(0)}</tspan>
+        <tspan>{name.slice(1)}</tspan>
+      </text>
+      {contested && (
+        <text
+          y={15}
+          textAnchor="middle"
+          fontSize={11.5}
+          fontFamily={FONT_BODY}
+          fontStyle="italic"
+          fill={RUBRIC}
+          style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 3 }}
+        >
+          ⚔ contested ⚔
+        </text>
+      )}
+    </g>
   );
 }
 
@@ -298,6 +403,15 @@ export function BoardMap({
         @keyframes tkid2glow { 0%,100% { stroke-opacity: 0.35; } 50% { stroke-opacity: 1; } }
       `}</style>
 
+      <defs>
+        <clipPath id="tkid2-island">
+          <path d={ISLAND_PATH} />
+          {ISLES.map((isle, i) => (
+            <path key={i} d={smoothClosed(isle)} />
+          ))}
+        </clipPath>
+      </defs>
+
       {/* Sea */}
       <rect x={0} y={0} width={680} height={800} rx={10} fill={SEA} />
       {/* Portolan rhumb lines */}
@@ -305,8 +419,8 @@ export function BoardMap({
         {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => {
           const angle = (i * Math.PI) / 8;
           const x = 90 + Math.cos(angle) * 900;
-          const y = 700 - Math.sin(angle) * 900;
-          return <line key={`a${i}`} x1={90} y1={700} x2={x} y2={y} />;
+          const y = 760 - Math.sin(angle) * 900;
+          return <line key={`a${i}`} x1={90} y1={760} x2={x} y2={y} />;
         })}
         {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => {
           const angle = Math.PI / 2 + (i * Math.PI) / 8;
@@ -315,11 +429,11 @@ export function BoardMap({
           return <line key={`b${i}`} x1={620} y1={120} x2={x} y2={y} />;
         })}
       </g>
-      <circle cx={90} cy={700} r={26} fill="none" stroke={RUBRIC} strokeWidth={1.4} opacity={0.5} />
-      <circle cx={90} cy={700} r={19} fill="none" stroke={INK_FADED} strokeWidth={1} opacity={0.5} />
-      <path d="M 90 678 L 95 695 L 90 691 L 85 695 Z" fill={RUBRIC} opacity={0.7} />
+      <circle cx={90} cy={760} r={26} fill="none" stroke={RUBRIC} strokeWidth={1.4} opacity={0.5} />
+      <circle cx={90} cy={760} r={19} fill="none" stroke={INK_FADED} strokeWidth={1} opacity={0.5} />
+      <path d="M 90 738 L 95 755 L 90 751 L 85 755 Z" fill={RUBRIC} opacity={0.7} />
 
-      {/* Regions */}
+      {/* Regions (clipped to the island silhouette) */}
       {(Object.keys(SHAPES) as RegionId[]).map((id) => {
         const shape = SHAPES[id];
         const color = REGION_COLOR[id];
@@ -327,6 +441,7 @@ export function BoardMap({
         const isContested = contested === id;
         const highlighted = !!highlightRegions?.has(id);
         const dimRegion = anyRegionHighlight && !highlighted;
+        const d = polyPath(shape.poly);
         return (
           <g
             key={id}
@@ -334,59 +449,47 @@ export function BoardMap({
             style={{ cursor: highlighted ? "pointer" : "default" }}
             opacity={dimRegion ? 0.45 : 1}
           >
-            <path
-              d={shape.path}
-              fill={color.fill}
-              stroke={color.edge}
-              strokeWidth={2.5}
-              strokeLinejoin="round"
-            />
-            {isContested && (
+            <g clipPath="url(#tkid2-island)">
               <path
-                d={shape.path}
-                fill="none"
-                stroke={GOLD}
-                strokeWidth={5}
-                strokeDasharray="10 7"
+                d={d}
+                fill={color.fill}
+                stroke={color.edge}
+                strokeWidth={2.5}
                 strokeLinejoin="round"
-                className="tkid2-region-glow"
               />
-            )}
-            {highlighted && (
-              <path
-                d={shape.path}
-                fill="rgba(255,251,232,0.25)"
-                stroke="#fffbe8"
-                strokeWidth={3.5}
-                strokeLinejoin="round"
-                className="tkid2-region-glow"
-              />
-            )}
+              {isContested && (
+                <>
+                  <path d={d} fill="rgba(200,162,68,0.18)" />
+                  <path
+                    d={d}
+                    fill="none"
+                    stroke={GOLD}
+                    strokeWidth={5}
+                    strokeDasharray="10 7"
+                    strokeLinejoin="round"
+                    className="tkid2-region-glow"
+                  />
+                </>
+              )}
+              {highlighted && (
+                <>
+                  <path d={d} fill="rgba(255,251,232,0.3)" />
+                  <path
+                    d={d}
+                    fill="none"
+                    stroke="#fffbe8"
+                    strokeWidth={3.5}
+                    strokeLinejoin="round"
+                    className="tkid2-region-glow"
+                  />
+                </>
+              )}
+            </g>
             <RegionLabel regionId={id} contested={isContested} />
-            {isContested && (
-              <text
-                x={shape.label[0]}
-                y={shape.label[1] + 16}
-                textAnchor="middle"
-                fontSize={11.5}
-                fontFamily={FONT_BODY}
-                fontStyle="italic"
-                fill={RUBRIC}
-                style={{ paintOrder: "stroke", stroke: PARCHMENT, strokeWidth: 3 }}
-              >
-                ⚔ contested ⚔
-              </text>
-            )}
             {region.control && (
-              <ControlDisc
-                x={SHAPES[id].cubes[0]}
-                y={SHAPES[id].cubes[1]}
-                faction={region.control}
-              />
+              <ControlDisc x={shape.cubes[0]} y={shape.cubes[1]} faction={region.control} />
             )}
-            {region.unstable && (
-              <InstabilityDisc x={SHAPES[id].cubes[0]} y={SHAPES[id].cubes[1]} />
-            )}
+            {region.unstable && <InstabilityDisc x={shape.cubes[0]} y={shape.cubes[1]} />}
             <RegionCubes
               state={state}
               regionId={id}
@@ -399,6 +502,21 @@ export function BoardMap({
         );
       })}
 
+      {/* Coastline over the region fills */}
+      <g pointerEvents="none">
+        <path d={ISLAND_PATH} fill="none" stroke={INK} strokeWidth={2.2} opacity={0.75} />
+        {ISLES.map((isle, i) => (
+          <path
+            key={i}
+            d={smoothClosed(isle)}
+            fill="none"
+            stroke={INK}
+            strokeWidth={2}
+            opacity={0.75}
+          />
+        ))}
+      </g>
+
       {/* France */}
       <g opacity={anyRegionHighlight ? 0.55 : 1}>
         <path
@@ -408,9 +526,10 @@ export function BoardMap({
           strokeWidth={2.5}
           strokeLinejoin="round"
         />
+        <path d={FRANCE_PATH} fill="none" stroke={INK} strokeWidth={2} opacity={0.6} />
         <text
-          x={552}
-          y={680}
+          x={598}
+          y={706}
           textAnchor="middle"
           fontFamily={FONT_BODY}
           fontSize={17}
@@ -422,12 +541,12 @@ export function BoardMap({
           <tspan>rance</tspan>
         </text>
         {Array.from({ length: state.instabilityInFrance }, (_, i) => (
-          <InstabilityDisc key={i} x={518 + i * 34} y={718} />
+          <InstabilityDisc key={i} x={562 + i * 36} y={744} />
         ))}
         {state.instabilityInFrance === 0 && (
           <text
-            x={552}
-            y={724}
+            x={598}
+            y={750}
             textAnchor="middle"
             fontSize={12}
             fontFamily={FONT_BODY}
@@ -489,13 +608,7 @@ export function BoardMap({
                 stroke={c.dark}
                 strokeWidth={1.8}
               />
-              <text
-                x={538}
-                y={y + 5.5}
-                fontFamily={FONT_BODY}
-                fontSize={15}
-                fill={INK}
-              >
+              <text x={538} y={y + 5.5} fontFamily={FONT_BODY} fontSize={15} fill={INK}>
                 × {state.supply[f]}
               </text>
               <text

--- a/src/features/tkid2/Tkid2Game.tsx
+++ b/src/features/tkid2/Tkid2Game.tsx
@@ -375,6 +375,141 @@ function describeEvents(events: Tkid2Event[], state: Tkid2State): string[] {
 }
 
 // ===========================================================================
+// AI turn overlay
+// ===========================================================================
+
+/** What the last AI action looked like, for the turn overlay. */
+interface BotFeed {
+  playerId: PlayerId;
+  name: string;
+  /** Card played, or null for a pass. */
+  cardId: CardId | null;
+  lines: string[];
+  ts: number;
+}
+
+function ThinkingDots() {
+  return (
+    <Box component="span" sx={{ display: "inline-flex", gap: "3px", ml: 0.5 }}>
+      {[0, 1, 2].map((i) => (
+        <Box
+          key={i}
+          component="span"
+          sx={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: RUBRIC,
+            animation: "tkid2dot 1.2s ease-in-out infinite",
+            animationDelay: `${i * 0.18}s`,
+          }}
+        />
+      ))}
+    </Box>
+  );
+}
+
+function BotTurnOverlay({
+  feed,
+  thinking,
+}: {
+  feed: BotFeed | null;
+  thinking: Tkid2Player | null;
+}) {
+  if (!feed && !thinking) return null;
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        top: 78,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 40,
+        pointerEvents: "none",
+        width: "min(94vw, 460px)",
+      }}
+    >
+      <Box
+        key={feed ? `feed-${feed.ts}` : `think-${thinking?.id}`}
+        sx={{
+          borderRadius: "8px",
+          border: `2px solid ${CARD_BACK}`,
+          outline: `1px solid ${GOLD}`,
+          outlineOffset: "-5px",
+          background: `linear-gradient(165deg, #f6eed6, ${PARCHMENT} 60%, ${PARCHMENT_DARK})`,
+          boxShadow: "0 10px 28px rgba(40,20,10,0.5)",
+          px: 2,
+          py: 1.2,
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          animation: "tkid2overlayin 240ms ease-out",
+        }}
+      >
+        {feed ? (
+          <>
+            {feed.cardId ? (
+              <ActionCardView cardId={feed.cardId} small />
+            ) : (
+              <Box
+                sx={{
+                  width: 46,
+                  height: 46,
+                  borderRadius: "50%",
+                  border: `2px solid ${INK_FADED}`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontFamily: FONT_UNCIAL,
+                  color: INK_FADED,
+                  fontSize: "0.9rem",
+                  flexShrink: 0,
+                }}
+              >
+                ✋
+              </Box>
+            )}
+            <Box sx={{ minWidth: 0 }}>
+              <Typography sx={{ fontFamily: FONT_UNCIAL, color: RUBRIC, fontSize: "0.95rem" }}>
+                {feed.cardId
+                  ? `${feed.name} plays ${CARD_INFO[feed.cardId].name}`
+                  : `${feed.name} passes`}
+              </Typography>
+              {feed.lines.slice(1).map((line, i) => (
+                <Typography
+                  key={`${i}-${line}`}
+                  sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.82rem", lineHeight: 1.35 }}
+                >
+                  {line}
+                </Typography>
+              ))}
+            </Box>
+          </>
+        ) : (
+          thinking && (
+            <>
+              <SmartToyIcon sx={{ color: INK_FADED }} />
+              <Typography
+                sx={{
+                  fontFamily: FONT_UNCIAL,
+                  color: RUBRIC,
+                  fontSize: "0.95rem",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                {thinking.name} is pondering their move
+                <ThinkingDots />
+              </Typography>
+            </>
+          )
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+// ===========================================================================
 // Game over
 // ===========================================================================
 
@@ -532,6 +667,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
   const [spyOpen, setSpyOpen] = React.useState(false);
   const [confirmNoEffect, setConfirmNoEffect] = React.useState<CardId | null>(null);
   const [notice, setNotice] = React.useState<string | null>(null);
+  const [botFeed, setBotFeed] = React.useState<BotFeed | null>(null);
 
   const stateRef = React.useRef(state);
   stateRef.current = state;
@@ -539,14 +675,40 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
   const applyLocal = React.useCallback((action: Tkid2Action) => {
     const prev = stateRef.current;
     if (!prev) return;
+    const actor = currentPlayer(prev);
     const res = applyAction(prev, action);
     if (res.error) {
       setNotice(res.error);
       return;
     }
     setState(res.state);
-    setLog((l) => [...describeEvents(res.events, prev).reverse(), ...l].slice(0, 24));
+    const lines = describeEvents(res.events, prev);
+    setLog((l) => [...lines.slice().reverse(), ...l].slice(0, 24));
+    // Feed the AI-turn overlay: a play or pass starts a new entry, the
+    // follow-up summon is appended to it.
+    if (actor.isBot) {
+      if (action.type === "play") {
+        setBotFeed({ playerId: actor.id, name: actor.name, cardId: action.cardId, lines, ts: Date.now() });
+      } else if (action.type === "pass") {
+        setBotFeed({ playerId: actor.id, name: actor.name, cardId: null, lines, ts: Date.now() });
+      } else {
+        setBotFeed((f) =>
+          f && f.playerId === actor.id
+            ? { ...f, lines: [...f.lines, ...lines], ts: Date.now() }
+            : f,
+        );
+      }
+    } else {
+      setBotFeed(null);
+    }
   }, []);
+
+  // The overlay lingers on an AI's finished move, then fades away.
+  React.useEffect(() => {
+    if (!botFeed) return;
+    const t = setTimeout(() => setBotFeed(null), 1800);
+    return () => clearTimeout(t);
+  }, [botFeed]);
 
   const start = (r: SetupResult) => {
     const players = [
@@ -708,8 +870,23 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
     else prompt = `Waiting for ${currentPlayer(state).name}…`;
   }
 
+  const thinkingBot =
+    state && !gameOver && !botFeed && currentPlayer(state).isBot
+      ? currentPlayer(state)
+      : null;
+
   return (
     <Dialog fullScreen open onClose={onExit} TransitionComponent={Transition as any}>
+      <style>{`
+        @keyframes tkid2overlayin {
+          from { opacity: 0; transform: translateY(-14px) scale(0.96); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+        @keyframes tkid2dot {
+          0%, 100% { opacity: 0.2; transform: translateY(0); }
+          50% { opacity: 1; transform: translateY(-3px); }
+        }
+      `}</style>
       <AppBar
         sx={{
           position: "relative",
@@ -742,6 +919,8 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
           </IconButton>
         </Toolbar>
       </AppBar>
+
+      {state && !gameOver && <BotTurnOverlay feed={botFeed} thinking={thinkingBot} />}
 
       <DialogContent
         sx={{

--- a/src/features/tkid2/ai/botPolicy.test.ts
+++ b/src/features/tkid2/ai/botPolicy.test.ts
@@ -2,6 +2,7 @@ import { chooseAction, evaluate } from "./botPolicy";
 import {
   Tkid2State,
   applyAction,
+  contestedRegionId,
   currentPlayer,
   gameResult,
   isGameOver,
@@ -30,6 +31,48 @@ describe("botPolicy", () => {
     expect(a).toEqual(b);
   });
 
+  it("passes when the contested struggle already favours its strategy", () => {
+    const state = newGame(PLAYERS, 40);
+    const contested = contestedRegionId(state)!;
+    // The contested region is safely Welsh, and this bot plays a Welsh game.
+    state.regions[contested].cubes = { scottish: 0, welsh: 4, english: 0 };
+    state.players[0].court = { scottish: 0, welsh: 3, english: 0 };
+    const action = chooseAction(state, "bot-1", "godlike");
+    expect(action.type).toBe("pass");
+  });
+
+  it("spends a card rather than pass into a losing game end", () => {
+    const state = newGame(PLAYERS, 41);
+    const contested = contestedRegionId(state)!;
+    // Two instability discs are already on the board; the contested region is
+    // tied, and both opponents have passed. Passing now resolves the region
+    // unstable → third disc → French invasion, which this bot loses on sets.
+    state.instabilityInFrance = 1;
+    state.regions.gwynedd.unstable = true;
+    state.regions.devon.unstable = true;
+    state.regions[contested].cubes = { scottish: 1, welsh: 1, english: 0 };
+    state.consecutivePasses = PLAYERS.length - 1;
+    state.players[0].court = { scottish: 2, welsh: 0, english: 0 }; // 0 sets
+    state.players[1].court = { scottish: 1, welsh: 1, english: 1 }; // 1 set
+    const action = chooseAction(state, "bot-1", "godlike");
+    expect(action.type).toBe("play");
+  });
+
+  it("does not dump its whole hand — cards survive a full bots game", () => {
+    let state: Tkid2State = newGame(PLAYERS, 9);
+    let steps = 0;
+    while (!isGameOver(state) && steps < 1000) {
+      const onTurn = currentPlayer(state).id;
+      const res = applyAction(state, chooseAction(state, onTurn, "godlike"));
+      expect(res.error).toBeUndefined();
+      state = res.state;
+      steps++;
+    }
+    expect(isGameOver(state)).toBe(true);
+    const cardsLeft = state.players.reduce((n, p) => n + p.hand.length, 0);
+    expect(cardsLeft).toBeGreaterThan(0);
+  });
+
   it("plays a bots-only game to completion at every difficulty", () => {
     for (const difficulty of ["easy", "normal", "godlike"] as const) {
       let state: Tkid2State = newGame(PLAYERS, 5, {
@@ -49,9 +92,8 @@ describe("botPolicy", () => {
     }
   });
 
-  it("evaluate prefers courts aligned with the strongest faction", () => {
+  it("evaluate prefers courts aligned with powerful factions", () => {
     const state = newGame(PLAYERS, 8);
-    // Give bot-1 a court stacked with the projected leader everywhere.
     const richer = JSON.parse(JSON.stringify(state)) as Tkid2State;
     richer.players[0].court = { scottish: 3, welsh: 3, english: 3 };
     expect(evaluate(richer, "bot-1")).toBeGreaterThan(evaluate(state, "bot-1"));

--- a/src/features/tkid2/ai/botPolicy.ts
+++ b/src/features/tkid2/ai/botPolicy.ts
@@ -2,22 +2,32 @@
  * The King Is Dead — NPC policy.
  *
  * Pure and deterministic: given a state and the id of the bot on turn, return
- * one legal `Tkid2Action`. One-ply greedy search: apply every legal action and
- * score the result with a heuristic estimating the bot's chance to be crowned.
+ * one legal `Tkid2Action`.
  *
- * The heuristic thinks like the game does:
- *  - project which faction will be the most powerful (regions controlled plus
- *    the leader of the currently contested region),
- *  - value court followers of factions weighted by how powerful those factions
- *    are projected to be,
- *  - value complete follower sets more as instability discs hit the board
- *    (they win the game if the French invade),
- *  - value holding cards a little (options are power).
+ * The bot is built to play like a human player:
+ *
+ *  - **Strategy from its cubes.** Its two random starting followers (and every
+ *    follower it summons later) anchor a strategy: it wants the factions it
+ *    holds in court to end up powerful, and steers the board that way. A bot
+ *    that starts with two Welsh cubes plays a Welsh game.
+ *  - **Cards are precious.** You get eight actions for the whole game, so the
+ *    default move is to PASS. A card is only played when its full effect
+ *    (including the follower summoned afterwards) improves the bot's position
+ *    by more than a scarcity-adjusted threshold — i.e. when it actually
+ *    matters, such as flipping the contested region before it resolves.
+ *  - **It watches the other players.** Opponents' courts count against every
+ *    faction's value: the bot avoids handing the win to whoever is best
+ *    aligned, and reacts when an opponent's play turns a struggle against it.
+ *
+ * Passing is evaluated by actually applying it — when the bot is the last to
+ * pass, the engine resolves the power struggle in the lookahead, so the bot
+ * "sees" exactly what locking in the current region means.
  */
 import {
   FACTIONS,
   Faction,
   PlayerId,
+  RegionId,
   Tkid2Action,
   Tkid2State,
   applyAction,
@@ -30,12 +40,14 @@ import {
   legalActions,
   majorityFaction,
   setCount,
+  summonOptions,
+  totalCubes,
 } from "../engine/tkid2Engine";
 
 export type Difficulty = "easy" | "normal" | "godlike";
 
-/** Projected power score per faction: regions held + leads in the contested
- *  region count as a probable extra region. */
+/** Projected power per faction: regions held, plus the contested region's
+ *  current leader counted as a probable extra win. */
 function projectedRegions(state: Tkid2State): Record<Faction, number> {
   const counts = { ...controlledCounts(state) };
   const contested = contestedRegionId(state);
@@ -61,27 +73,34 @@ export function evaluate(state: Tkid2State, botId: PlayerId): number {
   }
 
   const opponents = state.players.filter((p) => p.id !== botId);
-  const ranked = rankedFactions(state);
   const proj = projectedRegions(state);
+  const ranked = [...FACTIONS].sort((a, b) => proj[b] - proj[a]);
 
   let value = 0;
-  // Court alignment: margin over the best opponent, weighted by the faction's
-  // projected power (most powerful faction dominates the coronation).
+  // Court alignment: margin over the best-aligned opponent, weighted by how
+  // powerful the faction is projected to be.
   ranked.forEach((f, i) => {
-    const weight = [10, 4, 1][i] * (1 + proj[f] / 4);
     const bestOpp = opponents.reduce((m, p) => Math.max(m, p.court[f]), 0);
-    value += weight * (me.court[f] - bestOpp);
+    value += [10, 4, 1][i] * (me.court[f] - bestOpp);
   });
 
-  // Invasion insurance: sets matter more with each instability disc placed.
+  // Strategy: push the factions *I* hold toward power, and keep the factions
+  // my best-aligned rival holds away from it. This is what makes the bot
+  // commit to the colours of its starting cubes and react to other courts.
+  for (const f of FACTIONS) {
+    const bestOpp = opponents.reduce((m, p) => Math.max(m, p.court[f]), 0);
+    value += proj[f] * (1.6 * me.court[f] - 0.9 * bestOpp);
+  }
+
+  // Invasion insurance: complete sets matter more with each instability disc.
   const discs = instabilityOnBoard(state);
   const setWeight = [0.5, 4, 14][Math.min(discs, 2)];
   const bestOppSets = opponents.reduce((m, p) => Math.max(m, setCount(p.court)), 0);
   value += setWeight * (setCount(me.court) - bestOppSets);
 
-  // A slightly larger court and cards in hand are both flexibility.
+  // Unspent cards are future influence; a bigger court is flexibility.
+  value += 0.6 * me.hand.length;
   value += 0.3 * (me.court.scottish + me.court.welsh + me.court.english);
-  value += 0.4 * me.hand.length;
 
   return value;
 }
@@ -93,17 +112,100 @@ function actionKey(a: Tkid2Action): string {
   return `p-${a.cardId}-${JSON.stringify(a.params)}`;
 }
 
-const MAX_CANDIDATES = 400;
+/** Deterministic pseudo-noise in [-1, 1] so "normal" bots are imperfect but
+ *  reproducible. */
+function noise(state: Tkid2State, key: string): number {
+  let h = state.seed ^ (state.actionSeq * 2654435761);
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) | 0;
+  return (((h >>> 8) % 1000) / 500) - 1;
+}
 
-/** Deterministically thin very large action lists to keep the bot snappy. */
+const MAX_PLAYS = 90;
+
+/** Deterministically thin very large play lists to keep the bot snappy. */
 function thin(actions: Tkid2Action[]): Tkid2Action[] {
-  if (actions.length <= MAX_CANDIDATES) return actions;
-  const step = actions.length / MAX_CANDIDATES;
+  if (actions.length <= MAX_PLAYS) return actions;
+  const step = actions.length / MAX_PLAYS;
   const out: Tkid2Action[] = [];
-  for (let i = 0; i < MAX_CANDIDATES; i++) {
-    out.push(actions[Math.floor(i * step)]);
-  }
+  for (let i = 0; i < MAX_PLAYS; i++) out.push(actions[Math.floor(i * step)]);
   return out;
+}
+
+/** A short list of sensible summons: for each faction, the contested region
+ *  (summoning there shifts the struggle) plus the fullest other region. */
+function candidateSummons(state: Tkid2State): Tkid2Action[] {
+  const contested = contestedRegionId(state);
+  const options = summonOptions(state);
+  const picked = new Map<string, Tkid2Action>();
+  for (const f of FACTIONS) {
+    const inContested = options.find((o) => o.faction === f && o.regionId === contested);
+    if (inContested) {
+      picked.set(`${f}-c`, { type: "summon", ...inContested });
+    }
+    let best: { regionId: RegionId; faction: Faction } | null = null;
+    let bestSize = -1;
+    for (const o of options) {
+      if (o.faction !== f || o.regionId === contested) continue;
+      const size = totalCubes(state.regions[o.regionId].cubes);
+      if (size > bestSize) {
+        bestSize = size;
+        best = o;
+      }
+    }
+    if (best) picked.set(`${f}-o`, { type: "summon", ...best });
+  }
+  return Array.from(picked.values());
+}
+
+/** Value of a play measured after the follow-up summon it forces. */
+function playValue(state: Tkid2State, play: Tkid2Action, botId: PlayerId): number {
+  const res = applyAction(state, play);
+  if (res.error) return -Infinity;
+  if (!res.state.pendingSummon) return evaluate(res.state, botId);
+  let best = -Infinity;
+  for (const summon of candidateSummons(res.state)) {
+    const s2 = applyAction(res.state, summon);
+    if (s2.error) continue;
+    best = Math.max(best, evaluate(s2.state, botId));
+  }
+  return best === -Infinity ? evaluate(res.state, botId) : best;
+}
+
+/**
+ * How much better than passing a card play must be before it is worth one of
+ * the bot's eight actions. Grows when cards run scarcer than the remaining
+ * power struggles, so bots pace themselves across the whole game the way a
+ * human does.
+ */
+function playThreshold(state: Tkid2State, botId: PlayerId, difficulty: Difficulty): number {
+  const me = state.players.find((p) => p.id === botId);
+  const strugglesLeft = 8 - state.struggles.length;
+  const cardsLeft = me?.hand.filter((c) => c !== "plot").length ?? 0;
+  const scarcity = Math.max(0, strugglesLeft - cardsLeft) * 1.2;
+  const base = difficulty === "godlike" ? 1.0 : 2.4;
+  return base + scarcity;
+}
+
+/**
+ * The value of the summon that any card play would grant *right now*, with
+ * no card effect at all. Playing a card always banks a follower, but so
+ * would playing that same card on a later turn — so this windfall must not
+ * count in favour of playing now. It is subtracted from play values (scaled
+ * down late in the game, when unspent cards would otherwise go to waste).
+ */
+function summonWindfall(state: Tkid2State, botId: PlayerId): number {
+  const base = evaluate(state, botId);
+  const idx = state.players.findIndex((p) => p.id === botId);
+  if (idx < 0) return 0;
+  let best = 0;
+  for (const s of candidateSummons(state)) {
+    if (s.type !== "summon") continue;
+    const clone = JSON.parse(JSON.stringify(state)) as Tkid2State;
+    clone.regions[s.regionId].cubes[s.faction] -= 1;
+    clone.players[idx].court[s.faction] += 1;
+    best = Math.max(best, evaluate(clone, botId) - base);
+  }
+  return best;
 }
 
 export function chooseAction(
@@ -117,33 +219,62 @@ export function chooseAction(
 
   if (difficulty === "easy") return easyAction(state, all);
 
-  const actions = thin(all);
-  let best: Tkid2Action | null = null;
-  let bestScore = -Infinity;
-  for (const action of actions) {
-    const res = applyAction(state, action);
-    if (res.error) continue;
-    let score = evaluate(res.state, botId);
-    if (difficulty === "normal" && action.type === "play") {
-      // Normal bots slightly undervalue spending cards, making them play
-      // earlier (and more fallibly) than a godlike bot would.
-      score += 0.6;
+  // Mandatory summon after a card play: full one-ply evaluation.
+  if (state.pendingSummon) {
+    let best: Tkid2Action | null = null;
+    let bestScore = -Infinity;
+    for (const action of all) {
+      const res = applyAction(state, action);
+      if (res.error) continue;
+      const score = evaluate(res.state, botId);
+      if (score > bestScore || (score === bestScore && best && actionKey(action) < actionKey(best))) {
+        bestScore = score;
+        best = action;
+      }
     }
+    return best ?? all[0];
+  }
+
+  // Play-versus-pass: passing is the default; a card must earn its keep.
+  const pass: Tkid2Action = { type: "pass" };
+  const passRes = applyAction(state, pass);
+  const passValue = passRes.error ? -Infinity : evaluate(passRes.state, botId);
+
+  const plays = thin(all.filter((a) => a.type === "play"));
+  let bestPlay: Tkid2Action | null = null;
+  let bestValue = -Infinity;
+  for (const play of plays) {
+    let value = playValue(state, play, botId);
+    if (difficulty === "normal") value += noise(state, actionKey(play)) * 0.8;
     if (
-      score > bestScore ||
-      (score === bestScore && best !== null && actionKey(action) < actionKey(best))
+      value > bestValue ||
+      (value === bestValue && bestPlay && actionKey(play) < actionKey(bestPlay))
     ) {
-      bestScore = score;
-      best = action;
+      bestValue = value;
+      bestPlay = play;
     }
   }
-  return best ?? all[0];
+
+  // A play must beat "pass now and keep the card for later": its value is
+  // compared against passing plus the summon any future play would also
+  // grant. Once cards outnumber the remaining struggles, holding them back
+  // wastes them, so the windfall discount fades and bots start spending.
+  const me = currentPlayer(state);
+  const strugglesLeft = Math.max(1, 8 - state.struggles.length);
+  const cardsLeft = Math.max(1, me.hand.filter((c) => c !== "plot").length);
+  const hoardFactor = cardsLeft <= strugglesLeft ? 1 : strugglesLeft / cardsLeft;
+  const bar =
+    passValue +
+    summonWindfall(state, botId) * hoardFactor +
+    playThreshold(state, botId, difficulty);
+  if (bestPlay && bestValue > bar) return bestPlay;
+  return pass;
 }
 
 /**
- * Easy bots: when summoning, grab a follower of the projected strongest
- * faction; otherwise mostly pass, occasionally (deterministically) playing
- * whatever card comes first.
+ * Easy bots: pass most of the time, play whatever card comes first about
+ * every third opportunity, and when summoning grab a follower of the
+ * projected strongest faction.
  */
 function easyAction(state: Tkid2State, actions: Tkid2Action[]): Tkid2Action {
   const ranked = rankedFactions(state);
@@ -155,8 +286,7 @@ function easyAction(state: Tkid2State, actions: Tkid2Action[]): Tkid2Action {
     }
     return summons[0];
   }
-  // Play a card roughly every other opportunity, keyed off the action count.
-  const wantsToPlay = state.actionSeq % 2 === 0;
+  const wantsToPlay = state.actionSeq % 3 === 0 && state.consecutivePasses === 0;
   if (wantsToPlay) {
     const play = actions.find((a) => a.type === "play");
     if (play) return play;

--- a/src/features/tkid2/style.ts
+++ b/src/features/tkid2/style.ts
@@ -23,15 +23,16 @@ export const FACTION_COLOR: Record<Faction, { main: string; dark: string; light:
   english: { main: "#e0af2e", dark: "#a37a14", light: "#efcb69" },
 };
 
+/** Region fills matched to the printed board. */
 export const REGION_COLOR: Record<RegionId, { fill: string; edge: string }> = {
-  moray: { fill: "#8db3d6", edge: "#4a6f96" },
-  strathclyde: { fill: "#d3aa4b", edge: "#96742a" },
-  lancaster: { fill: "#79ab8f", edge: "#47755c" },
-  northumbria: { fill: "#dfa8b4", edge: "#a56b78" },
-  gwynedd: { fill: "#b05446", edge: "#7a3229" },
-  warwick: { fill: "#cd7f45", edge: "#95562a" },
-  essex: { fill: "#b9c465", edge: "#7f8a3c" },
-  devon: { fill: "#8caf5b", edge: "#5d7c37" },
+  moray: { fill: "#7fa3c9", edge: "#48688c" },
+  strathclyde: { fill: "#c2a24a", edge: "#8a6f2b" },
+  lancaster: { fill: "#5f9683", edge: "#3a6455" },
+  northumbria: { fill: "#dca7b4", edge: "#a06a79" },
+  gwynedd: { fill: "#9e4a3e", edge: "#6d2d24" },
+  warwick: { fill: "#517e87", edge: "#33565e" },
+  essex: { fill: "#b3bf62", edge: "#7c883b" },
+  devon: { fill: "#7fa95d", edge: "#547539" },
 };
 
 export const FRANCE_COLOR = { fill: "#9aa5b5", edge: "#5e6a7d" };

--- a/src/features/tkid2/useTkid2BotDriver.ts
+++ b/src/features/tkid2/useTkid2BotDriver.ts
@@ -16,8 +16,11 @@ import {
   isGameOver,
 } from "./engine/tkid2Engine";
 
-const MIN_DELAY_MS = 650;
-const MAX_DELAY_MS = 1250;
+/** "Thinking time" before an AI decides to play or pass (shown as an
+ *  animated overlay in the UI). */
+export const BOT_THINK_MS = 2000;
+/** Shorter beat before the follow-up summon so a turn reads as one motion. */
+export const BOT_SUMMON_MS = 700;
 
 export interface UseTkid2BotDriverArgs {
   state: Tkid2State | null;
@@ -49,10 +52,7 @@ export function useTkid2BotDriver({
 
     let cancelled = false;
     const difficulty = difficultyById?.[player.id] ?? "normal";
-    // Summons follow a card play; keep them snappy so a bot turn reads as
-    // one motion.
-    const base = state.pendingSummon ? 350 : MIN_DELAY_MS;
-    const delay = base + Math.random() * (MAX_DELAY_MS - MIN_DELAY_MS) * (state.pendingSummon ? 0.4 : 1);
+    const delay = state.pendingSummon ? BOT_SUMMON_MS : BOT_THINK_MS;
 
     const timer = setTimeout(() => {
       if (cancelled) return;


### PR DESCRIPTION
## Summary

Follow-up to #21 (the rulebook rebuild, already merged). This PR contains only the newest round of changes:

### Accurate board map (`BoardMap.tsx`, `style.ts`)
- Britain redrawn after the printed board: a real coastline silhouette (Hebrides, Scottish sea lochs, Solway and Humber inlets, East Anglia, Kent, the Welsh and Cornish peninsulas) with the eight territories tiled inside it and clipped to the coast.
- Angled region labels for the diagonal Lancaster/Northumbria strips (and Gwynedd/Strathclyde), matching the board's typography.
- Region colours matched to the board; no pictorial decorations (no castles) — clean fills with cubes and discs.
- France sits across the Channel holding the instability discs.

### Human-like AI (`ai/botPolicy.ts`)
Fixes bots dumping all eight cards while the human plays one:
- **Passing is the default.** A card play is baselined against "pass now, play this card later": the summon any play grants is discounted, so only a card's actual board effect can justify spending it. A scarcity-adjusted threshold paces the hand across the whole game, and the discount fades late so leftover cards get spent rather than wasted.
- **Strategy from its cubes.** Bots commit to the factions in their court (starting from their two random setup cubes) and steer the board so those factions gain power.
- **Reacts to other players.** Opponents' courts count against each faction's value; because passing is evaluated by actually resolving the would-be power struggle in lookahead, bots intervene when a struggle is about to lock in against them and pass to lock in ones they're winning.
- New regression tests: passes when the contested struggle favours it, spends a card rather than pass into a losing game end, and finishes a full bots game with cards still in hand.

### AI turn overlay (`Tkid2Game.tsx`, `useTkid2BotDriver.ts`)
- Every AI turn shows an animated parchment overlay: **2 seconds of "pondering" per AI player**, then the played card (rendered as the actual card) or the pass, plus what happened — the summon and any power-struggle result. Non-blocking and fades out on the human's turn.

## Testing
- Full suite passes (122 tests), including the new bot-behaviour regression tests.
- Production build compiles cleanly.
- Smoke-tested headlessly (Playwright/Chromium): map rendering, thinking + result overlay phases, and multi-struggle pacing showing bots passing regularly while holding cards — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166xtknHYRAXfANrHj3yfbb