### PR TITLE
TKID: setup contrast, mobile layout, AI pacing, richer chronicle with animated history replay

### DIFF
--- a/src/features/tkid2/BoardMap.tsx
+++ b/src/features/tkid2/BoardMap.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {
   FACTIONS,
   Faction,
+  REGION_IDS,
   RegionId,
   Tkid2State,
   regionName,
@@ -168,6 +169,160 @@ const CUBE_GAP = 23;
 const CUBES_PER_ROW = 4;
 const MAX_VISIBLE_CUBES = 12;
 
+/** Centre of each faction's cube in the supply box (flight endpoints). */
+const SUPPLY_POS: Record<Faction, Pt> = {
+  scottish: [517.5, 96],
+  welsh: [517.5, 132],
+  english: [517.5, 168],
+};
+
+// ---------------------------------------------------------------------------
+// Move animations
+// ---------------------------------------------------------------------------
+// The board animates the *difference* between the previous and the next state
+// it is asked to draw: followers fly between regions, to and from the supply,
+// and up into a court. Because it is diff-based it needs no knowledge of the
+// action that happened — stepping backwards through the game history animates
+// the same moves in reverse for free.
+
+const FLIGHT_MS = 650;
+/** Above this many simultaneous flights the change reads as a scene change
+ *  (e.g. jumping far through the history), not a move — skip the animation. */
+const MAX_FLIGHTS = 20;
+
+interface Flight {
+  id: number;
+  faction: Faction;
+  from: Pt;
+  to: Pt;
+  /** "move" travels visibly; "out" fades away upward (into a court);
+   *  "in" is the reverse (a court transfer undone in the history view). */
+  mode: "move" | "out" | "in";
+  delay: number;
+}
+
+function computeFlights(prev: Tkid2State, next: Tkid2State): Omit<Flight, "id">[] {
+  const out: Omit<Flight, "id">[] = [];
+  for (const f of FACTIONS) {
+    const sources: Pt[] = [];
+    const sinks: Pt[] = [];
+    for (const id of REGION_IDS) {
+      const d = next.regions[id].cubes[f] - prev.regions[id].cubes[f];
+      const pos = SHAPES[id].cubes;
+      for (let i = 0; i < -d; i++) sources.push(pos);
+      for (let i = 0; i < d; i++) sinks.push(pos);
+    }
+    let supplyDelta = next.supply[f] - prev.supply[f];
+    // Region → region.
+    while (sources.length > 0 && sinks.length > 0) {
+      out.push({ faction: f, from: sources.pop()!, to: sinks.pop()!, mode: "move", delay: 0 });
+    }
+    // Region → supply.
+    while (sources.length > 0 && supplyDelta > 0) {
+      out.push({ faction: f, from: sources.pop()!, to: SUPPLY_POS[f], mode: "move", delay: 0 });
+      supplyDelta--;
+    }
+    // Supply → region.
+    while (sinks.length > 0 && supplyDelta < 0) {
+      out.push({ faction: f, from: SUPPLY_POS[f], to: sinks.pop()!, mode: "move", delay: 0 });
+      supplyDelta++;
+    }
+    // Region → court: the follower rises from the region and fades away.
+    while (sources.length > 0) {
+      const p = sources.pop()!;
+      out.push({ faction: f, from: p, to: [p[0], p[1] - 52], mode: "out", delay: 0 });
+    }
+    // Court → region (stepping backwards over a summon).
+    while (sinks.length > 0) {
+      const p = sinks.pop()!;
+      out.push({ faction: f, from: [p[0], p[1] - 52], to: p, mode: "in", delay: 0 });
+    }
+  }
+  // Stagger and fan out parallel flights slightly so they stay readable.
+  return out.map((fl, i) => ({
+    ...fl,
+    delay: i * 70,
+    from: [fl.from[0] + (i % 3) * 6 - 6, fl.from[1]] as Pt,
+  }));
+}
+
+function FlightCube({ flight, onDone }: { flight: Flight; onDone: (id: number) => void }) {
+  const [go, setGo] = React.useState(false);
+  React.useEffect(() => {
+    // Two frames so the browser paints the start position before the
+    // transition to the target begins.
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setGo(true));
+    });
+    const t = setTimeout(() => onDone(flight.id), flight.delay + FLIGHT_MS + 150);
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+      clearTimeout(t);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const c = FACTION_COLOR[flight.faction];
+  const [x, y] = go ? flight.to : flight.from;
+  const opacity = flight.mode === "out" ? (go ? 0 : 1) : flight.mode === "in" ? (go ? 1 : 0) : 1;
+  return (
+    <g
+      pointerEvents="none"
+      style={{
+        transform: `translate(${x}px, ${y}px)`,
+        transition: `transform ${FLIGHT_MS}ms cubic-bezier(0.4, 0, 0.25, 1) ${flight.delay}ms, opacity ${FLIGHT_MS}ms ease ${flight.delay}ms`,
+        opacity,
+      }}
+    >
+      <rect
+        x={-CUBE / 2 - 3}
+        y={-CUBE / 2 - 3}
+        width={CUBE + 6}
+        height={CUBE + 6}
+        rx={4}
+        fill="none"
+        stroke="#fffbe8"
+        strokeWidth={2.5}
+        opacity={0.85}
+      />
+      <rect
+        x={-CUBE / 2}
+        y={-CUBE / 2}
+        width={CUBE}
+        height={CUBE}
+        rx={2.5}
+        fill={c.main}
+        stroke={c.dark}
+        strokeWidth={1.8}
+      />
+    </g>
+  );
+}
+
+/** Flights for the state changes the board is displaying. */
+function useFlights(state: Tkid2State): [Flight[], (id: number) => void] {
+  const [flights, setFlights] = React.useState<Flight[]>([]);
+  const seq = React.useRef(1);
+  const prevRef = React.useRef(state);
+
+  React.useEffect(() => {
+    const prev = prevRef.current;
+    prevRef.current = state;
+    if (prev === state) return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const specs = computeFlights(prev, state);
+    if (specs.length === 0 || specs.length > MAX_FLIGHTS) return;
+    setFlights((cur) => [...cur, ...specs.map((s) => ({ ...s, id: seq.current++ }))]);
+  }, [state]);
+
+  const remove = React.useCallback((id: number) => {
+    setFlights((cur) => cur.filter((f) => f.id !== id));
+  }, []);
+  return [flights, remove];
+}
+
 export interface BoardMapProps {
   state: Tkid2State;
   contested: RegionId | null;
@@ -329,8 +484,10 @@ function ControlDisc({ x, y, faction }: { x: number; y: number; faction: Faction
   const c = FACTION_COLOR[faction];
   return (
     <g transform={`translate(${x}, ${y})`}>
-      <circle r={13} fill={c.main} stroke={c.dark} strokeWidth={2.5} />
-      <circle r={7.5} fill="none" stroke={c.light} strokeWidth={2} opacity={0.9} />
+      <g className="tkid2-disc-in">
+        <circle r={13} fill={c.main} stroke={c.dark} strokeWidth={2.5} />
+        <circle r={7.5} fill="none" stroke={c.light} strokeWidth={2} opacity={0.9} />
+      </g>
     </g>
   );
 }
@@ -338,8 +495,10 @@ function ControlDisc({ x, y, faction }: { x: number; y: number; faction: Faction
 function InstabilityDisc({ x, y }: { x: number; y: number }) {
   return (
     <g transform={`translate(${x}, ${y})`}>
-      <circle r={13} fill={INSTABILITY} stroke="#2b1e12" strokeWidth={2.5} />
-      <circle r={7.5} fill="none" stroke="#6d5233" strokeWidth={2} opacity={0.9} />
+      <g className="tkid2-disc-in">
+        <circle r={13} fill={INSTABILITY} stroke="#2b1e12" strokeWidth={2.5} />
+        <circle r={7.5} fill="none" stroke="#6d5233" strokeWidth={2} opacity={0.9} />
+      </g>
     </g>
   );
 }
@@ -388,6 +547,7 @@ export function BoardMap({
 }: BoardMapProps) {
   const anyRegionHighlight = !!highlightRegions && highlightRegions.size > 0;
   const anyCubeHighlight = !!highlightCubes && highlightCubes.size > 0;
+  const [flights, removeFlight] = useFlights(state);
 
   return (
     <svg
@@ -399,8 +559,13 @@ export function BoardMap({
       <style>{`
         .tkid2-pulse { animation: tkid2pulse 1.1s ease-in-out infinite; }
         .tkid2-region-glow { animation: tkid2glow 1.2s ease-in-out infinite; }
+        .tkid2-disc-in { animation: tkid2discin 480ms cubic-bezier(0.34, 1.4, 0.64, 1); transform-box: fill-box; transform-origin: center; }
         @keyframes tkid2pulse { 0%,100% { opacity: 0.25; } 50% { opacity: 1; } }
         @keyframes tkid2glow { 0%,100% { stroke-opacity: 0.35; } 50% { stroke-opacity: 1; } }
+        @keyframes tkid2discin { from { transform: scale(0); } to { transform: scale(1); } }
+        @media (prefers-reduced-motion: reduce) {
+          .tkid2-disc-in { animation: none; }
+        }
       `}</style>
 
       <defs>
@@ -624,6 +789,13 @@ export function BoardMap({
             </g>
           );
         })}
+      </g>
+
+      {/* Followers in flight (animated diffs between displayed states) */}
+      <g pointerEvents="none">
+        {flights.map((fl) => (
+          <FlightCube key={fl.id} flight={fl} onDone={removeFlight} />
+        ))}
       </g>
     </svg>
   );

--- a/src/features/tkid2/RegionCardTrack.tsx
+++ b/src/features/tkid2/RegionCardTrack.tsx
@@ -63,6 +63,7 @@ export function RegionCardTrack({
               textAlign: "center",
               cursor: highlighted ? "pointer" : "default",
               opacity: anyHighlight && !highlighted && !picked ? 0.45 : 1,
+              perspective: "500px",
             }}
           >
             {/* Numbered space */}
@@ -78,9 +79,19 @@ export function RegionCardTrack({
               {isContested ? " ⚔" : ""}
             </Typography>
             <Box
+              /* Remount when the card here changes (Negotiate swap) or flips
+                 face down (struggle resolved), replaying the flip animation —
+                 including when stepping through the history view. */
+              key={`${slot.regionId}-${slot.faceUp}`}
               sx={{
                 height: 96,
                 borderRadius: "6px",
+                animation: "tkid2cardflip 420ms ease-out",
+                "@keyframes tkid2cardflip": {
+                  from: { transform: "rotateY(80deg)", opacity: 0.3 },
+                  to: { transform: "rotateY(0deg)", opacity: 1 },
+                },
+                "@media (prefers-reduced-motion: reduce)": { animation: "none" },
                 border: `2.5px solid ${
                   picked ? GOLD : isContested ? RUBRIC : highlighted ? "#fffbe8" : "#5d2019"
                 }`,
@@ -142,6 +153,12 @@ export function RegionCardTrack({
                     background: NEGOTIATION,
                     border: `2px solid #9a8c6d`,
                     boxShadow: "0 1px 2px rgba(0,0,0,0.4)",
+                    animation: "tkid2discpop 360ms cubic-bezier(0.34, 1.5, 0.64, 1)",
+                    "@keyframes tkid2discpop": {
+                      from: { transform: "scale(0)" },
+                      to: { transform: "scale(1)" },
+                    },
+                    "@media (prefers-reduced-motion: reduce)": { animation: "none" },
                   }}
                   title="Negotiation disc"
                 />

--- a/src/features/tkid2/Tkid2Game.tsx
+++ b/src/features/tkid2/Tkid2Game.tsx
@@ -16,6 +16,8 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import CloseIcon from "@mui/icons-material/Close";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import RefreshIcon from "@mui/icons-material/Refresh";
@@ -33,7 +35,9 @@ import {
   FACTION_LABEL,
   Faction,
   FactionCounts,
+  Placement,
   PlayerId,
+  RegionId,
   Tkid2Action,
   Tkid2Event,
   Tkid2Player,
@@ -175,16 +179,40 @@ interface SetupResult {
   advanced: boolean;
 }
 
+/** The app theme defaults to dark mode, which gives MUI toggle buttons white
+ *  text — unreadable on this parchment background. Style them explicitly. */
+const toggleGroupSx = {
+  mt: 0.5,
+  flexWrap: "wrap" as const,
+  "& .MuiToggleButton-root": {
+    fontFamily: FONT_BODY,
+    fontWeight: 700,
+    color: INK,
+    borderColor: "#b89968",
+    background: "rgba(255,252,240,0.55)",
+    px: { xs: 1.25, sm: 2 },
+    py: 0.6,
+    lineHeight: 1.3,
+    "&:hover": { background: "rgba(255,252,240,0.9)" },
+    "&.Mui-selected": {
+      color: "#fdf3d8",
+      background: `linear-gradient(180deg, #a13c30, ${CARD_BACK})`,
+      borderColor: "#4a1812",
+      "&:hover": { background: "#8e3a2e" },
+    },
+  },
+};
+
 function SetupScreen({ onStart }: { onStart: (r: SetupResult) => void }) {
   const [botCount, setBotCount] = React.useState(2);
   const [difficulty, setDifficulty] = React.useState<Difficulty>("normal");
   const [advanced, setAdvanced] = React.useState(false);
 
   return (
-    <Stack spacing={2.5} sx={{ maxWidth: 520, mx: "auto", mt: 2, pb: 4 }}>
+    <Stack spacing={2.5} sx={{ maxWidth: 520, mx: "auto", mt: 2, pb: 4, px: { xs: 0.5, sm: 0 } }}>
       <Box sx={{ textAlign: "center" }}>
         <Tkid2Logo size={84} />
-        <Typography sx={{ fontFamily: FONT_UNCIAL, fontSize: "1.9rem", color: RUBRIC, mt: 1 }}>
+        <Typography sx={{ fontFamily: FONT_UNCIAL, fontSize: { xs: "1.6rem", sm: "1.9rem" }, color: RUBRIC, mt: 1 }}>
           The King is Dead
         </Typography>
         <Typography sx={{ fontFamily: FONT_BODY, fontStyle: "italic", color: INK_FADED }}>
@@ -211,7 +239,7 @@ function SetupScreen({ onStart }: { onStart: (r: SetupResult) => void }) {
               exclusive
               value={botCount}
               onChange={(_, v) => v && setBotCount(v)}
-              sx={{ mt: 0.5 }}
+              sx={toggleGroupSx}
             >
               <ToggleButton value={1}>1 AI</ToggleButton>
               <ToggleButton value={2}>2 AI</ToggleButton>
@@ -230,7 +258,7 @@ function SetupScreen({ onStart }: { onStart: (r: SetupResult) => void }) {
               exclusive
               value={difficulty}
               onChange={(_, v) => v && setDifficulty(v)}
-              sx={{ mt: 0.5 }}
+              sx={toggleGroupSx}
             >
               <ToggleButton value="easy">Easy</ToggleButton>
               <ToggleButton value="normal">Normal</ToggleButton>
@@ -243,10 +271,15 @@ function SetupScreen({ onStart }: { onStart: (r: SetupResult) => void }) {
               exclusive
               value={advanced}
               onChange={(_, v) => v !== null && setAdvanced(v)}
-              sx={{ mt: 0.5 }}
+              sx={toggleGroupSx}
             >
               <ToggleButton value={false}>Basic game</ToggleButton>
-              <ToggleButton value={true}>Advanced (cunning cards)</ToggleButton>
+              <ToggleButton value={true}>
+                Advanced
+                <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
+                  &nbsp;(cunning cards)
+                </Box>
+              </ToggleButton>
             </ToggleButtonGroup>
             <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.8rem", color: INK_FADED, mt: 0.5 }}>
               Advanced: the three Support cards are replaced by three secret
@@ -333,21 +366,116 @@ function PlayerPanel({
   );
 }
 
+const factionArticle = (f: Faction) => (f === "english" ? "an" : "a");
+
+/** "a Welsh follower", "2 Scottish followers and an English follower", … */
+function describeFollowers(fs: Faction[]): string {
+  const counts = new Map<Faction, number>();
+  for (const f of fs) counts.set(f, (counts.get(f) ?? 0) + 1);
+  const parts = Array.from(counts.entries()).map(([f, n]) =>
+    n === 1
+      ? `${factionArticle(f)} ${FACTION_LABEL[f]} follower`
+      : `${n} ${FACTION_LABEL[f]} followers`,
+  );
+  return parts.join(" and ");
+}
+
+function describePlacements(placements: Placement[]): string {
+  const byRegion = new Map<RegionId, Faction[]>();
+  for (const p of placements) {
+    byRegion.set(p.regionId, [...(byRegion.get(p.regionId) ?? []), p.faction]);
+  }
+  return Array.from(byRegion.entries())
+    .map(([r, fs]) => `${describeFollowers(fs)} into ${regionName(r)}`)
+    .join(" and ");
+}
+
+function joinSentence(parts: string[]): string | null {
+  if (parts.length === 0) return null;
+  const s = parts.join(", then ");
+  return s[0].toUpperCase() + s.slice(1) + ".";
+}
+
+/** One sentence saying what a card play actually did on the board — so the
+ *  chronicle reads "played Negotiate — swapped Essex and Devon", not just
+ *  "played Negotiate". `prev` is the state before the play resolved. */
+function describePlay(prev: Tkid2State, cardId: CardId, params: CardParams): string | null {
+  switch (cardId) {
+    case "negotiate": {
+      if (params.slotA === undefined || params.slotB === undefined) return null;
+      const a = prev.slots.find((s) => s.position === params.slotA);
+      const b = prev.slots.find((s) => s.position === params.slotB);
+      if (!a || !b) return null;
+      const disc = params.discRegionId
+        ? `; the negotiation disc goes to ${regionName(params.discRegionId)}`
+        : "";
+      return `Swapped the region cards of ${regionName(a.regionId)} (space ${a.position}) and ${regionName(b.regionId)} (space ${b.position})${disc}.`;
+    }
+    case "manoeuvre":
+    case "outmanoeuvre":
+    case "influence":
+    case "dispute":
+    case "edict": {
+      const { from, to } = params;
+      if (!from || !to) return null;
+      return `Swapped ${describeFollowers(from.factions)} in ${regionName(from.regionId)} with ${describeFollowers(to.factions)} in ${regionName(to.regionId)}.`;
+    }
+    case "march": {
+      const { from, to } = params;
+      if (!from || !to || from.factions.length === 0) return null;
+      return `Marched ${describeFollowers(from.factions)} from ${regionName(from.regionId)} into ${regionName(to.regionId)}.`;
+    }
+    case "ambush": {
+      const parts: string[] = [];
+      if (params.placements?.length) parts.push(`placed ${describePlacements(params.placements)}`);
+      if (params.returnFactions?.length && params.regionId) {
+        parts.push(
+          `returned ${describeFollowers(params.returnFactions)} from ${regionName(params.regionId)} to the supply`,
+        );
+      }
+      return joinSentence(parts);
+    }
+    case "quell":
+    case "muster":
+    case "suppress": {
+      const parts: string[] = [];
+      if (params.returnFactions?.length && params.regionId) {
+        parts.push(
+          `returned ${describeFollowers(params.returnFactions)} from ${regionName(params.regionId)} to the supply`,
+        );
+      }
+      if (params.placements?.length) parts.push(`placed ${describePlacements(params.placements)}`);
+      return joinSentence(parts);
+    }
+    default: {
+      if (params.placements?.length) return `Placed ${describePlacements(params.placements)}.`;
+      return null;
+    }
+  }
+}
+
 function describeEvents(events: Tkid2Event[], state: Tkid2State): string[] {
   const name = (id: PlayerId) => state.players.find((p) => p.id === id)?.name ?? id;
   const lines: string[] = [];
   for (const e of events) {
     switch (e.kind) {
-      case "played":
+      case "played": {
         lines.push(
           e.viaSpy
             ? `${name(e.playerId)} copied ${CARD_INFO[e.cardId].name} with Spy.`
             : `${name(e.playerId)} played ${CARD_INFO[e.cardId].name}.`,
         );
+        const detail = e.params ? describePlay(state, e.cardId, e.params) : null;
+        if (detail) {
+          lines.push(detail);
+        } else if (e.cardId !== "spy" && (!e.params || Object.keys(e.params).length === 0)) {
+          lines.push("It had no effect on the board.");
+        }
         break;
+      }
       case "summoned":
         lines.push(
-          `${name(e.playerId)} summoned a ${FACTION_LABEL[e.faction]} follower from ${regionName(e.regionId)}.`,
+          `${name(e.playerId)} summoned ${factionArticle(e.faction)} ${FACTION_LABEL[e.faction]} follower from ${regionName(e.regionId)}.`,
         );
         break;
       case "summonSkipped":
@@ -421,7 +549,7 @@ function BotTurnOverlay({
     <Box
       sx={{
         position: "fixed",
-        top: 78,
+        top: { xs: 62, sm: 78 },
         left: "50%",
         transform: "translateX(-50%)",
         zIndex: 40,
@@ -658,11 +786,26 @@ function RulesDialog({ open, onClose }: { open: boolean; onClose: () => void }) 
 // Root component
 // ===========================================================================
 
+/** One completed move (a card play plus its summon, or a pass) in the
+ *  chronicle, with the board as it looked afterwards for the history view. */
+interface ChronicleEntry {
+  id: number;
+  actorId: PlayerId;
+  /** Card played, or null for a pass. */
+  cardId: CardId | null;
+  lines: string[];
+  stateAfter: Tkid2State;
+}
+
+const MAX_CHRONICLE = 64;
+
 export function Tkid2Game({ onExit }: { onExit: () => void }) {
   const [state, setState] = React.useState<Tkid2State | null>(null);
   const [config, setConfig] = React.useState<SetupResult | null>(null);
   const [selection, setSelection] = React.useState<Selection | null>(null);
-  const [log, setLog] = React.useState<string[]>([]);
+  const [entries, setEntries] = React.useState<ChronicleEntry[]>([]);
+  /** Index into `entries` while replaying history; null = live play. */
+  const [reviewIndex, setReviewIndex] = React.useState<number | null>(null);
   const [showHelp, setShowHelp] = React.useState(false);
   const [spyOpen, setSpyOpen] = React.useState(false);
   const [confirmNoEffect, setConfirmNoEffect] = React.useState<CardId | null>(null);
@@ -671,6 +814,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
 
   const stateRef = React.useRef(state);
   stateRef.current = state;
+  const entrySeq = React.useRef(1);
 
   const applyLocal = React.useCallback((action: Tkid2Action) => {
     const prev = stateRef.current;
@@ -683,7 +827,28 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
     }
     setState(res.state);
     const lines = describeEvents(res.events, prev);
-    setLog((l) => [...lines.slice().reverse(), ...l].slice(0, 24));
+    setEntries((es) => {
+      // The summon completes the card play before it: merge into one move.
+      if (action.type === "summon") {
+        const last = es[es.length - 1];
+        if (last && last.actorId === actor.id && last.cardId) {
+          return [
+            ...es.slice(0, -1),
+            { ...last, lines: [...last.lines, ...lines], stateAfter: res.state },
+          ];
+        }
+      }
+      return [
+        ...es,
+        {
+          id: entrySeq.current++,
+          actorId: actor.id,
+          cardId: action.type === "play" ? action.cardId : null,
+          lines,
+          stateAfter: res.state,
+        },
+      ].slice(-MAX_CHRONICLE);
+    });
     // Feed the AI-turn overlay: a play or pass starts a new entry, the
     // follow-up summon is appended to it.
     if (actor.isBot) {
@@ -703,10 +868,12 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
     }
   }, []);
 
-  // The overlay lingers on an AI's finished move, then fades away.
+  // The overlay lingers on an AI's finished move — longer when there is more
+  // to read — then fades away.
   React.useEffect(() => {
     if (!botFeed) return;
-    const t = setTimeout(() => setBotFeed(null), 1800);
+    const linger = 2200 + 600 * Math.max(0, botFeed.lines.length - 1);
+    const t = setTimeout(() => setBotFeed(null), linger);
     return () => clearTimeout(t);
   }, [botFeed]);
 
@@ -723,14 +890,16 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
     setState(newGame(players, seed, { advanced: r.advanced }));
     setConfig(r);
     setSelection(null);
-    setLog([]);
+    setEntries([]);
+    setReviewIndex(null);
   };
 
   const reset = () => {
     setState(null);
     setConfig(null);
     setSelection(null);
-    setLog([]);
+    setEntries([]);
+    setReviewIndex(null);
   };
 
   // Auto-clear notices.
@@ -751,20 +920,36 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
     return map;
   }, [botIds, config]);
 
+  // History review: while the user steps back through the chronicle, the
+  // board shows that snapshot and the game (including the bots) pauses.
+  const reviewing =
+    state !== null && reviewIndex !== null && reviewIndex < entries.length;
+  const shownState = reviewing ? entries[reviewIndex!].stateAfter : state;
+
   useTkid2BotDriver({
     state,
     botIds,
     difficultyById,
     onAction: applyLocal,
-    enabled: !showHelp,
+    enabled: !showHelp && !reviewing,
   });
 
   const gameOver = state !== null && isGameOver(state);
-  const contested = state ? contestedRegionId(state) : null;
+  const contested = shownState ? contestedRegionId(shownState) : null;
   const human = state?.players.find((p) => p.id === HUMAN_ID);
   const humanTurn =
-    !!state && !gameOver && currentPlayer(state).id === HUMAN_ID;
+    !!state && !gameOver && !reviewing && currentPlayer(state).id === HUMAN_ID;
   const humanSummon = humanTurn && !!state && state.pendingSummon;
+
+  const goBack = () => {
+    if (entries.length === 0) return;
+    setSelection(null);
+    setBotFeed(null);
+    setReviewIndex((i) => (i === null ? entries.length - 1 : Math.max(0, i - 1)));
+  };
+  const goForward = () => {
+    setReviewIndex((i) => (i === null || i >= entries.length - 1 ? null : i + 1));
+  };
 
   const targets = React.useMemo(
     () => (selection ? getTargets(selection) : null),
@@ -857,13 +1042,15 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
     });
   }, [state, spyOpen]);
 
-  const counts = state ? controlledCounts(state) : null;
+  const counts = shownState ? controlledCounts(shownState) : null;
 
   // ------------------------------------------------------------------
   // Prompt banner content
   // ------------------------------------------------------------------
   let prompt: string | null = null;
-  if (state && !gameOver) {
+  if (state && reviewing) {
+    prompt = `Reviewing move ${reviewIndex! + 1} of ${entries.length} — the game is paused.`;
+  } else if (state && !gameOver) {
     if (selection && targets && !targets.done) prompt = targets.prompt;
     else if (humanSummon) prompt = "Summon a follower to your court — tap any follower on the map.";
     else if (humanTurn) prompt = "Your turn — play a card or pass.";
@@ -871,7 +1058,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
   }
 
   const thinkingBot =
-    state && !gameOver && !botFeed && currentPlayer(state).isBot
+    state && !gameOver && !reviewing && !botFeed && currentPlayer(state).isBot
       ? currentPlayer(state)
       : null;
 
@@ -894,25 +1081,55 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
           borderBottom: `3px solid ${GOLD}`,
         }}
       >
-        <Toolbar>
+        <Toolbar sx={{ px: { xs: 1, sm: 2 }, minHeight: { xs: 54 } }}>
           <Tkid2Logo size={34} sx={{ marginRight: 10 }} />
           <Typography
-            sx={{ flex: 1, color: "#fdf3d8", fontFamily: FONT_UNCIAL, fontSize: "1.25rem" }}
+            sx={{
+              flex: 1,
+              color: "#fdf3d8",
+              fontFamily: FONT_UNCIAL,
+              fontSize: { xs: "1.05rem", sm: "1.25rem" },
+              minWidth: 0,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
           >
             The King is Dead
           </Typography>
           {state && (
-            <Button color="inherit" startIcon={<RefreshIcon />} onClick={reset} sx={{ mr: 1, fontFamily: FONT_BODY }}>
-              New
+            <Button
+              color="inherit"
+              startIcon={<RefreshIcon />}
+              onClick={reset}
+              sx={{
+                mr: { xs: 0, sm: 1 },
+                fontFamily: FONT_BODY,
+                minWidth: 0,
+                px: { xs: 1, sm: 2 },
+                "& .MuiButton-startIcon": { mr: { xs: 0, sm: 1 }, ml: 0 },
+              }}
+            >
+              <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
+                New
+              </Box>
             </Button>
           )}
           <Button
             color="inherit"
             startIcon={<HelpOutlineIcon />}
             onClick={() => setShowHelp(true)}
-            sx={{ mr: 1, fontFamily: FONT_BODY }}
+            sx={{
+              mr: { xs: 0, sm: 1 },
+              fontFamily: FONT_BODY,
+              minWidth: 0,
+              px: { xs: 1, sm: 2 },
+              "& .MuiButton-startIcon": { mr: { xs: 0, sm: 1 }, ml: 0 },
+            }}
           >
-            Rules
+            <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
+              Rules
+            </Box>
           </Button>
           <IconButton edge="end" color="inherit" onClick={onExit} aria-label="close">
             <CloseIcon />
@@ -920,7 +1137,9 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
         </Toolbar>
       </AppBar>
 
-      {state && !gameOver && <BotTurnOverlay feed={botFeed} thinking={thinkingBot} />}
+      {state && !gameOver && !reviewing && (
+        <BotTurnOverlay feed={botFeed} thinking={thinkingBot} />
+      )}
 
       <DialogContent
         sx={{
@@ -930,7 +1149,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
       >
         {!state && <SetupScreen onStart={start} />}
 
-        {state && (
+        {state && shownState && (
           <Stack spacing={1.5} sx={{ maxWidth: 1200, mx: "auto", pb: 2 }}>
             {/* Status strip */}
             <Stack
@@ -944,7 +1163,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
               <Typography sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.9rem" }}>
                 Struggle{" "}
                 <b>
-                  {Math.min(state.struggles.length + 1, 8)}
+                  {Math.min(shownState.struggles.length + 1, 8)}
                 </b>{" "}
                 of 8
               </Typography>
@@ -981,19 +1200,19 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
                   }}
                 />
                 <Typography sx={{ fontFamily: FONT_BODY, color: INK, fontSize: "0.9rem" }}>
-                  {3 - state.instabilityInFrance}/3
+                  {3 - shownState.instabilityInFrance}/3
                 </Typography>
               </Stack>
             </Stack>
 
-            {gameOver && <GameOverPanel state={state} onAgain={reset} />}
+            {gameOver && !reviewing && <GameOverPanel state={state} onAgain={reset} />}
 
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "flex-start" }}>
               {/* Map column */}
               <Box sx={{ flex: "1 1 380px", maxWidth: 640, mx: "auto" }}>
                 <Box sx={{ mb: 1 }}>
                   <RegionCardTrack
-                    state={state}
+                    state={shownState}
                     contested={contested}
                     highlightSlots={highlightSlots}
                     pickedSlots={selection?.slotsPicked}
@@ -1011,7 +1230,7 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
                   }}
                 >
                   <BoardMap
-                    state={state}
+                    state={shownState}
                     contested={contested}
                     highlightRegions={highlightRegions}
                     highlightCubes={highlightCubes}
@@ -1023,40 +1242,111 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
               </Box>
 
               {/* Side column: courts & chronicle */}
-              <Stack spacing={1} sx={{ flex: "1 1 300px", minWidth: 280 }}>
+              <Stack spacing={1} sx={{ flex: "1 1 300px", minWidth: { xs: 0, sm: 280 }, width: "100%" }}>
                 <UncialHeading>Courts</UncialHeading>
-                {state.players.map((p, i) => (
+                {shownState.players.map((p) => (
                   <PlayerPanel
                     key={p.id}
-                    state={state}
+                    state={shownState}
                     player={p}
                     isTeammate={
-                      state.players.length === 4 &&
+                      shownState.players.length === 4 &&
                       p.id !== HUMAN_ID &&
-                      state.players[(state.players.findIndex((q) => q.id === HUMAN_ID) + 2) % 4].id === p.id
+                      shownState.players[
+                        (shownState.players.findIndex((q) => q.id === HUMAN_ID) + 2) % 4
+                      ].id === p.id
                     }
                   />
                 ))}
-                <UncialHeading>Chronicle</UncialHeading>
-                <ParchmentPanel sx={{ p: 1, maxHeight: 190, overflowY: "auto" }}>
-                  {log.length === 0 && (
+                <Stack direction="row" alignItems="center" spacing={0.25}>
+                  <UncialHeading>Chronicle</UncialHeading>
+                  <Box sx={{ flexGrow: 1 }} />
+                  <Tooltip title="Step back through the previous moves">
+                    <span>
+                      <IconButton
+                        size="small"
+                        onClick={goBack}
+                        disabled={entries.length === 0 || reviewIndex === 0}
+                        aria-label="previous move"
+                        sx={{ color: INK }}
+                      >
+                        <ChevronLeftIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={goForward}
+                      disabled={!reviewing}
+                      aria-label="next move"
+                      sx={{ color: INK }}
+                    >
+                      <ChevronRightIcon fontSize="small" />
+                    </IconButton>
+                  </span>
+                  <Button
+                    size="small"
+                    onClick={() => setReviewIndex(null)}
+                    disabled={!reviewing}
+                    sx={{
+                      fontFamily: FONT_BODY,
+                      color: RUBRIC,
+                      textTransform: "none",
+                      minWidth: 0,
+                      px: 0.75,
+                      "&.Mui-disabled": { color: INK_FADED, opacity: 0.5 },
+                    }}
+                  >
+                    Now
+                  </Button>
+                </Stack>
+                <ParchmentPanel sx={{ p: 1, maxHeight: { xs: 170, sm: 220 }, overflowY: "auto" }}>
+                  {entries.length === 0 && (
                     <Typography sx={{ fontFamily: FONT_BODY, fontStyle: "italic", color: INK_FADED, fontSize: "0.82rem" }}>
                       The chronicle of the struggle will be written here…
                     </Typography>
                   )}
-                  {log.map((line, i) => (
-                    <Typography
-                      key={`${i}-${line}`}
-                      sx={{
-                        fontFamily: FONT_BODY,
-                        fontSize: "0.82rem",
-                        color: i === 0 ? INK : INK_FADED,
-                        lineHeight: 1.45,
-                      }}
-                    >
-                      {line}
-                    </Typography>
-                  ))}
+                  {entries
+                    .map((entry, idx) => {
+                      const latest = idx === entries.length - 1;
+                      const selected = reviewing && reviewIndex === idx;
+                      return (
+                        <Box
+                          key={entry.id}
+                          onClick={() => {
+                            setSelection(null);
+                            setBotFeed(null);
+                            setReviewIndex(latest ? null : idx);
+                          }}
+                          sx={{
+                            borderLeft: `3px solid ${selected ? GOLD : "transparent"}`,
+                            borderRadius: "3px",
+                            background: selected ? "rgba(200,162,68,0.16)" : "none",
+                            pl: 0.75,
+                            py: 0.2,
+                            mb: 0.3,
+                            cursor: "pointer",
+                          }}
+                        >
+                          {entry.lines.map((line, li) => (
+                            <Typography
+                              key={`${li}-${line}`}
+                              sx={{
+                                fontFamily: FONT_BODY,
+                                fontSize: "0.82rem",
+                                color: latest || selected ? INK : INK_FADED,
+                                lineHeight: 1.45,
+                                pl: li > 0 ? 1.25 : 0,
+                              }}
+                            >
+                              {line}
+                            </Typography>
+                          ))}
+                        </Box>
+                      );
+                    })
+                    .reverse()}
                 </ParchmentPanel>
               </Stack>
             </Box>
@@ -1095,6 +1385,16 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
                     >
                       {notice ?? prompt}
                     </Typography>
+                    {reviewing && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => setReviewIndex(null)}
+                        sx={{ fontFamily: FONT_BODY, color: RUBRIC, borderColor: RUBRIC, textTransform: "none" }}
+                      >
+                        Back to now
+                      </Button>
+                    )}
                     {selection &&
                       targets?.variants?.map((v, i) => (
                         <Button

--- a/src/features/tkid2/Tkid2Game.tsx
+++ b/src/features/tkid2/Tkid2Game.tsx
@@ -120,7 +120,21 @@ function CourtCubes({ court }: { court: FactionCounts }) {
       {FACTIONS.map((f) => (
         <Stack key={f} direction="row" spacing={0.4} alignItems="center">
           <FactionCube faction={f} />
-          <Typography sx={{ fontFamily: FONT_BODY, fontSize: "0.85rem", color: INK }}>
+          <Typography
+            // Remount on count change so the pop animation replays.
+            key={court[f]}
+            sx={{
+              fontFamily: FONT_BODY,
+              fontSize: "0.85rem",
+              color: INK,
+              animation: "tkid2countpop 380ms cubic-bezier(0.34, 1.5, 0.64, 1)",
+              "@keyframes tkid2countpop": {
+                from: { transform: "scale(1.7)", color: RUBRIC },
+                to: { transform: "scale(1)" },
+              },
+              "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+            }}
+          >
             {court[f]}
           </Typography>
         </Stack>
@@ -355,7 +369,18 @@ function PlayerPanel({
       <Box sx={{ flexGrow: 1 }} />
       {topDiscard ? (
         <Tooltip title={`Last played: ${CARD_INFO[topDiscard].name}`}>
-          <Box>
+          <Box
+            // Remount when a new card lands on the pile → slide-in replay.
+            key={`${topDiscard}-${player.discard.length}`}
+            sx={{
+              animation: "tkid2cardin 320ms ease-out",
+              "@keyframes tkid2cardin": {
+                from: { transform: "translateY(-8px) scale(0.9)", opacity: 0 },
+                to: { transform: "translateY(0) scale(1)", opacity: 1 },
+              },
+              "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+            }}
+          >
             <ActionCardView cardId={topDiscard} small />
           </Box>
         </Tooltip>
@@ -1327,6 +1352,12 @@ export function Tkid2Game({ onExit }: { onExit: () => void }) {
                             py: 0.2,
                             mb: 0.3,
                             cursor: "pointer",
+                            animation: "tkid2entryin 300ms ease-out",
+                            "@keyframes tkid2entryin": {
+                              from: { transform: "translateY(-6px)", opacity: 0 },
+                              to: { transform: "translateY(0)", opacity: 1 },
+                            },
+                            "@media (prefers-reduced-motion: reduce)": { animation: "none" },
                           }}
                         >
                           {entry.lines.map((line, li) => (

--- a/src/features/tkid2/ai/botPolicy.test.ts
+++ b/src/features/tkid2/ai/botPolicy.test.ts
@@ -58,6 +58,35 @@ describe("botPolicy", () => {
     expect(action.type).toBe("play");
   });
 
+  it("paces itself: at most half the hand goes into the first struggle", () => {
+    // Against a human who only passes, bots used to trade cards over the
+    // first contested region until their hands were nearly empty.
+    for (const seed of [1, 7, 42, 99, 12345]) {
+      const players = [
+        { id: "human", name: "You", isBot: false },
+        { id: "bot-1", name: "AI 1", isBot: true },
+        { id: "bot-2", name: "AI 2", isBot: true },
+      ];
+      let state: Tkid2State = newGame(players, seed);
+      let steps = 0;
+      while (!isGameOver(state) && state.struggles.length === 0 && steps < 300) {
+        const p = currentPlayer(state);
+        const action = p.isBot
+          ? chooseAction(state, p.id, "normal")
+          : ({ type: "pass" } as const);
+        const res = applyAction(state, action);
+        expect(res.error).toBeUndefined();
+        state = res.state;
+        steps++;
+      }
+      expect(state.struggles.length).toBe(1);
+      for (const p of state.players) {
+        if (!p.isBot) continue;
+        expect(8 - p.hand.length).toBeLessThanOrEqual(4);
+      }
+    }
+  });
+
   it("does not dump its whole hand — cards survive a full bots game", () => {
     let state: Tkid2State = newGame(PLAYERS, 9);
     let steps = 0;

--- a/src/features/tkid2/ai/botPolicy.ts
+++ b/src/features/tkid2/ai/botPolicy.ts
@@ -183,7 +183,17 @@ function playThreshold(state: Tkid2State, botId: PlayerId, difficulty: Difficult
   const cardsLeft = me?.hand.filter((c) => c !== "plot").length ?? 0;
   const scarcity = Math.max(0, strugglesLeft - cardsLeft) * 1.2;
   const base = difficulty === "godlike" ? 1.0 : 2.4;
-  return base + scarcity;
+  // Pacing: eight cards must last eight struggles. Once a bot has spent more
+  // cards than there are resolved struggles, each further play this round
+  // costs steeply more — otherwise two bots trading blows over the first
+  // contested region dump their whole hands before it even resolves. A
+  // genuinely game-deciding play still goes through, because losing the game
+  // evaluates far below any threshold.
+  const spent = me?.discard.length ?? 0;
+  const overspend = Math.max(0, spent - state.struggles.length);
+  const perCard = difficulty === "godlike" ? 2.6 : 3.4;
+  const pacing = ((overspend * (overspend + 1)) / 2) * perCard;
+  return base + scarcity + pacing;
 }
 
 /**

--- a/src/features/tkid2/engine/tkid2Engine.ts
+++ b/src/features/tkid2/engine/tkid2Engine.ts
@@ -411,7 +411,14 @@ export type Tkid2Action =
   | { type: "summon"; regionId: RegionId; faction: Faction };
 
 export type Tkid2Event =
-  | { kind: "played"; playerId: PlayerId; cardId: CardId; viaSpy?: boolean }
+  | {
+      kind: "played";
+      playerId: PlayerId;
+      cardId: CardId;
+      viaSpy?: boolean;
+      /** The parameters the card was resolved with (for log descriptions). */
+      params?: CardParams;
+    }
   | { kind: "summoned"; playerId: PlayerId; regionId: RegionId; faction: Faction }
   | { kind: "summonSkipped"; playerId: PlayerId }
   | { kind: "passed"; playerId: PlayerId }
@@ -1509,7 +1516,13 @@ export function applyAction(state: Tkid2State, action: Tkid2Action): ApplyResult
     const top = target?.discard[target.discard.length - 1];
     if (top) {
       resolveCardEffect(next, top, action.params.spyParams ?? {});
-      events.push({ kind: "played", playerId: np.id, cardId: top, viaSpy: true });
+      events.push({
+        kind: "played",
+        playerId: np.id,
+        cardId: top,
+        viaSpy: true,
+        params: action.params.spyParams ?? {},
+      });
     }
   } else {
     resolveCardEffect(next, action.cardId, action.params);
@@ -1524,7 +1537,12 @@ export function applyAction(state: Tkid2State, action: Tkid2Action): ApplyResult
     np.emptyHandSeq = next.actionSeq;
   }
   next.consecutivePasses = 0;
-  events.unshift({ kind: "played", playerId: np.id, cardId: action.cardId });
+  events.unshift({
+    kind: "played",
+    playerId: np.id,
+    cardId: action.cardId,
+    params: action.params,
+  });
 
   // Summon a follower to court — mandatory, skipped only when impossible.
   if (summonOptions(next).length > 0) {

--- a/src/features/tkid2/useTkid2BotDriver.ts
+++ b/src/features/tkid2/useTkid2BotDriver.ts
@@ -18,7 +18,7 @@ import {
 
 /** "Thinking time" before an AI decides to play or pass (shown as an
  *  animated overlay in the UI). */
-export const BOT_THINK_MS = 2000;
+export const BOT_THINK_MS = 2400;
 /** Shorter beat before the follow-up summon so a turn reads as one motion. */
 export const BOT_SUMMON_MS = 700;
 


### PR DESCRIPTION
Fixes the playtest feedback on The King Is Dead and adds animations throughout, including when stepping through the move history.

## Setup screen contrast
The app theme defaults to dark mode, which gave the MUI toggle buttons white text on the parchment background. The Opponents / Difficulty / Rules toggles are now styled explicitly: ink text on parchment, with the selected option in dark red with cream text.

## Mobile optimisation (incl. iPhone 13 mini)
- Compact app bar on small screens: icon-only New/Rules buttons, smaller truncating title.
- Toggle groups wrap; the "Advanced (cunning cards)" label shortens to "Advanced" on phones (the explanation below it stays).
- AI-turn overlay offset adjusted for the shorter mobile toolbar; setup screen paddings and font sizes tuned for 375 px wide viewports.

## AI no longer dumps its hand in round one
Reproduced in simulation: with a human who only passes, bots played 4–8 of their 8 cards before the first power struggle (one seed: all 8) — two bots kept flipping the contested region back and forth, and every flip looked "worth it". The play threshold now includes a pacing penalty: once a bot has spent more cards than there are resolved struggles, each further play that round costs steeply more. Game-deciding plays still go through (a lost game evaluates far below any threshold). After the fix bots play at most ~2–4 cards into a hot first struggle; covered by a regression test that simulates the passing human.

## Chronicle now says *what* happened
`played` events carry their card parameters, and the log describes each play concretely, e.g.:
- "AI 1 played Negotiate. — Swapped the region cards of Warwick (space 2) and Moray (space 8); the negotiation disc goes to Warwick."
- "AI 2 played Manoeuvre. — Swapped an English follower in Lancaster with a Welsh follower in Northumbria."

Also fixes the "a English follower" grammar, and groups each play with its follow-up summon as one move.

## History replay
Chevron buttons next to the Chronicle (and tapping any entry) step back through snapshots of previous moves — the board, courts, and status strip show the game as it was after that move. The game (including the bots) pauses while reviewing; "Now" / "Back to now" returns to live play.

## Animations
- **Follower moves**: the board animates the *diff* between the states it displays — cubes visibly fly between regions, to/from the supply box, and rise into a court when summoned. Because it is diff-based, stepping through the history replays the same animations, backwards and forwards.
- **Region card track**: cards flip when Negotiate swaps them or a struggle turns them face down; the negotiation disc pops in.
- Control/instability discs scale in; court counters pop on summon; the last-played card slides into the player panel; new chronicle entries fade in.
- The AI-turn overlay lingers longer when there is more to read, and bot think time is slightly longer.
- All animations respect `prefers-reduced-motion`.

## Testing
- 123 tests pass (new regression test for AI pacing).
- `CI=true` production build compiles with no warnings.
- Verified end-to-end with Playwright at desktop and iPhone 13 mini viewports: setup contrast, gameplay flow, chronicle detail lines, history stepping (flights confirmed mid-animation in both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqwNdH4btECdV2LfC7csMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqwNdH4btECdV2LfC7csMN)_